### PR TITLE
Quickmenu unlock position from head rotation and angle configuration

### DIFF
--- a/ValheimVRMod/Scripts/QuickAbstract.cs
+++ b/ValheimVRMod/Scripts/QuickAbstract.cs
@@ -28,17 +28,23 @@ namespace ValheimVRMod.Scripts {
             refreshItems();
             createSphere();
         }
-        
+
         private void OnEnable() {
             transform.SetParent(parent, false);
             transform.localPosition = Vector3.zero;
 
-            //Config Version (more to muscle memory than seeing)
-            //transform.localRotation = Quaternion.Euler(VHVRConfig.getQuickMenuAngle(), 0, -5);
 
-            //Camera Version
-            Camera vrCam = CameraUtils.getCamera(CameraUtils.VR_CAMERA);
-            transform.LookAt(vrCam.transform.position);
+            
+            if (VHVRConfig.getQuickMenuFollowCam()) {
+                //Camera Version
+                Camera vrCam = CameraUtils.getCamera(CameraUtils.VR_CAMERA);
+                transform.LookAt(vrCam.transform.position);
+            }
+            else {
+                //Hand Version
+                transform.localRotation = Quaternion.Euler(VHVRConfig.getQuickMenuAngle(), 0, -5);
+            }
+            
 
             transform.SetParent(Player.m_localPlayer.transform);
             transform.parent = null;

--- a/ValheimVRMod/Scripts/QuickAbstract.cs
+++ b/ValheimVRMod/Scripts/QuickAbstract.cs
@@ -32,7 +32,14 @@ namespace ValheimVRMod.Scripts {
         private void OnEnable() {
             transform.SetParent(parent, false);
             transform.localPosition = Vector3.zero;
-            transform.localRotation = Quaternion.Euler(VHVRConfig.getQuickMenuAngle(), 0, -5);
+
+            //Config Version (more to muscle memory than seeing)
+            //transform.localRotation = Quaternion.Euler(VHVRConfig.getQuickMenuAngle(), 0, -5);
+
+            //Camera Version
+            Camera vrCam = CameraUtils.getCamera(CameraUtils.VR_CAMERA);
+            transform.LookAt(vrCam.transform.position);
+
             transform.SetParent(Player.m_localPlayer.transform);
             transform.parent = null;
             offset = transform.position - Player.m_localPlayer.transform.position ;

--- a/ValheimVRMod/Scripts/QuickAbstract.cs
+++ b/ValheimVRMod/Scripts/QuickAbstract.cs
@@ -19,7 +19,6 @@ namespace ValheimVRMod.Scripts {
         private GameObject sphere;
 
         public Transform parent;
-        public Transform grandParent;
         private Vector3 offset;
 
         private void Awake() {

--- a/ValheimVRMod/Scripts/QuickAbstract.cs
+++ b/ValheimVRMod/Scripts/QuickAbstract.cs
@@ -19,8 +19,9 @@ namespace ValheimVRMod.Scripts {
         private GameObject sphere;
 
         public Transform parent;
-        
-        
+        public Transform grandParent;
+        private Vector3 offset;
+
         private void Awake() {
             
             elements = new GameObject[MAX_ELEMENTS];
@@ -32,10 +33,13 @@ namespace ValheimVRMod.Scripts {
         private void OnEnable() {
             transform.SetParent(parent, false);
             transform.localPosition = Vector3.zero;
-            transform.localRotation = Quaternion.Euler(107, 0, -5);
+            transform.localRotation = Quaternion.Euler(VHVRConfig.getQuickMenuAngle(), 0, -5);
             transform.SetParent(Player.m_localPlayer.transform);
+            transform.parent = null;
+            offset = transform.position - Player.m_localPlayer.transform.position ;
         }
         private void Update() {
+            transform.position = offset + Player.m_localPlayer.transform.position;
             sphere.transform.position = parent.position;
             hoverItem();
         }
@@ -132,7 +136,6 @@ namespace ValheimVRMod.Scripts {
                 elements[i].transform.localPosition = position;
             }
         }
-        
         private void hoverItem() {
 
             float maxDist = 0.05f;

--- a/ValheimVRMod/Scripts/SpearManager.cs
+++ b/ValheimVRMod/Scripts/SpearManager.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using UnityEngine;
 using Valve.VR;
+using ValheimVRMod.VRCore;
 
 namespace ValheimVRMod.Scripts {
     public class SpearManager : MonoBehaviour {
@@ -8,7 +9,7 @@ namespace ValheimVRMod.Scripts {
         private int tickCounter;
         private List<Vector3> snapshots = new List<Vector3>();
         private GameObject fixedSpear;
-        
+
         public static Vector3 spawnPoint;
         public static Vector3 aimDir;
         public static bool isThrowing;
@@ -28,34 +29,39 @@ namespace ValheimVRMod.Scripts {
                 return;
             }
 
+            if (snapshots.Count < 3) {
+                return;
+            }
+
             if (isThrowing) {
                 return;
             }
 
+            
+            Vector3 posEnd = snapshots[snapshots.Count-1];
+            Vector3 posStart = snapshots[0];
             spawnPoint = transform.position;
-            var dist = 0.0f;
-            Vector3 posEnd = spawnPoint;
-            Vector3 posStart = spawnPoint;
 
-            foreach (Vector3 snapshot in snapshots) {
-                var curDist = Vector3.Distance(snapshot, posEnd);
-                if (curDist > dist) {
-                    dist = curDist;
-                    posStart = snapshot;
-                }
+            aimDir = (posEnd - posStart)*2;
+
+
+            if (Vector3.Distance(posEnd,posStart) > 0.16f&& VRPlayer.justUnsheathed == false) {
+                isThrowing = true;
             }
-
-            aimDir = (posEnd - posStart).normalized;
-            isThrowing = true;
         }
-
         private void FixedUpdate() {
             tickCounter++;
             if (tickCounter < 5) {
                 return;
             }
 
-            snapshots.Add(fixedSpear.transform.position);
+            if (VRPlayer.justUnsheathed == true) {
+                snapshots.Clear();
+            }
+            else {
+                snapshots.Add(fixedSpear.transform.localPosition - Player.m_localPlayer.transform.position);
+            }
+            
 
             if (snapshots.Count > MAX_SNAPSHOTS) {
                 snapshots.RemoveAt(0);

--- a/ValheimVRMod/Utilities/VHVRConfig.cs
+++ b/ValheimVRMod/Utilities/VHVRConfig.cs
@@ -50,6 +50,7 @@ namespace ValheimVRMod.Utilities
         private static ConfigEntry<float> DebugRotZ;
         private static ConfigEntry<float> DebugScale;
         private static ConfigEntry<bool> unlockDesktopCursor;
+        private static ConfigEntry<bool> QuickMenuFollowCam;
         private static ConfigEntry<int> QuickMenuAngle;
 
         // Controls Settings
@@ -253,9 +254,13 @@ namespace ValheimVRMod.Utilities
                 false,
                 "Normally the desktop cursor is locked to the center of the screen to avoid having the player accidentally lose focus when playing. This option can be used to free the mouse " +
                 "cursor which some users may want, especially if exclusively using motion controls where window focus is not needed.");
+            QuickMenuFollowCam = config.Bind("UI",
+                "QuickMenuFollowCam",
+                true,
+                "If Set to true, the quickmenu will rotate towards your head (ignoring Quickmenu angle option),if set to false, it will rotate towards your hands at start");
             QuickMenuAngle = config.Bind("UI",
                 "QuickMenuAngle",
-                107,
+                60,
                 "Set the quickmenu vertical angle ");
         }
 
@@ -581,6 +586,9 @@ namespace ValheimVRMod.Utilities
             return unlockDesktopCursor.Value;
         }
 
+        public static bool getQuickMenuFollowCam() {
+            return QuickMenuFollowCam.Value;
+        }
         public static int getQuickMenuAngle()
         {
             return QuickMenuAngle.Value;

--- a/ValheimVRMod/Utilities/VHVRConfig.cs
+++ b/ValheimVRMod/Utilities/VHVRConfig.cs
@@ -50,6 +50,7 @@ namespace ValheimVRMod.Utilities
         private static ConfigEntry<float> DebugRotZ;
         private static ConfigEntry<float> DebugScale;
         private static ConfigEntry<bool> unlockDesktopCursor;
+        private static ConfigEntry<int> QuickMenuAngle;
 
         // Controls Settings
         private static ConfigEntry<bool> nonVrPlayer;
@@ -252,6 +253,10 @@ namespace ValheimVRMod.Utilities
                 false,
                 "Normally the desktop cursor is locked to the center of the screen to avoid having the player accidentally lose focus when playing. This option can be used to free the mouse " +
                 "cursor which some users may want, especially if exclusively using motion controls where window focus is not needed.");
+            QuickMenuAngle = config.Bind("UI",
+                "QuickMenuAngle",
+                107,
+                "Set the quickmenu vertical angle ");
         }
 
         private static void InitializeControlsSettings(ConfigFile config)
@@ -576,5 +581,9 @@ namespace ValheimVRMod.Utilities
             return unlockDesktopCursor.Value;
         }
 
+        public static int getQuickMenuAngle()
+        {
+            return QuickMenuAngle.Value;
+        }
     }
 }

--- a/ValheimVRMod/VRCore/VRPlayer.cs
+++ b/ValheimVRMod/VRCore/VRPlayer.cs
@@ -51,6 +51,7 @@ namespace ValheimVRMod.VRCore
         private static Vector3 THIRD_PERSON_3_OFFSET = new Vector3(0f, 3.2f, -4.4f);
         private static Vector3 THIRD_PERSON_CONFIG_OFFSET = Vector3.zero;
         private static float NECK_OFFSET = 0.2f;
+        public static bool justUnsheathed = false;
 
         private static GameObject _prefab;
         private static GameObject _instance;
@@ -850,7 +851,6 @@ namespace ValheimVRMod.VRCore
         {
             var camera = CameraUtils.getCamera(CameraUtils.VR_CAMERA).transform;
             var action = SteamVR_Actions.valheim_Grab;
-            
             if (camera.InverseTransformPoint(hand.transform.position).y > -0.4f &&
                 camera.InverseTransformPoint(hand.transform.position).z < 0)
             {
@@ -859,15 +859,25 @@ namespace ValheimVRMod.VRCore
                 {
                     toggleShowHand = false;
                     hand.hapticAction.Execute(0, 0.2f, 100, 0.3f, inputSource);
-                    
-                    if (isRightHand && EquipScript.getLeft() == EquipType.Bow) {
+                    if(isRightHand && isHoldingItem(isRightHand) && (EquipScript.getRight() == EquipType.Spear || EquipScript.getRight() == EquipType.SpearChitin)) {
+
+                    } else if (isRightHand && EquipScript.getLeft() == EquipType.Bow) {
                         BowLocalManager.instance.toggleArrow();
                     } else if (isHoldingItem(isRightHand)) {
                         getPlayerCharacter().HideHandItems();
                     } else {
                         getPlayerCharacter().ShowHandItems();
+                        justUnsheathed = true;
                     }
                 }
+                else if (!justUnsheathed && isRightHand && action.GetStateUp(inputSource)) {
+                    if (isHoldingItem(isRightHand) && (EquipScript.getRight() == EquipType.Spear || EquipScript.getRight() == EquipType.SpearChitin)) {
+                        getPlayerCharacter().HideHandItems();
+                    }
+                }
+            }
+            if (justUnsheathed && isRightHand && action.GetStateUp(inputSource)&& (EquipScript.getRight() == EquipType.Spear || EquipScript.getRight() == EquipType.SpearChitin)) {
+                justUnsheathed = false;
             }
         }
 

--- a/ValheimVRMod/VRCore/VRPlayer.cs
+++ b/ValheimVRMod/VRCore/VRPlayer.cs
@@ -859,7 +859,7 @@ namespace ValheimVRMod.VRCore
                 {
                     toggleShowHand = false;
                     hand.hapticAction.Execute(0, 0.2f, 100, 0.3f, inputSource);
-                    if(isRightHand && isHoldingItem(isRightHand) && (EquipScript.getRight() == EquipType.Spear || EquipScript.getRight() == EquipType.SpearChitin)) {
+                    if(isRightHand && isHoldingItem(isRightHand) && isHoldingSpear()) {
 
                     } else if (isRightHand && EquipScript.getLeft() == EquipType.Bow) {
                         BowLocalManager.instance.toggleArrow();
@@ -876,11 +876,13 @@ namespace ValheimVRMod.VRCore
                     }
                 }
             }
-            if (justUnsheathed && isRightHand && action.GetStateUp(inputSource)&& (EquipScript.getRight() == EquipType.Spear || EquipScript.getRight() == EquipType.SpearChitin)) {
+            if (justUnsheathed && isRightHand && action.GetStateUp(inputSource)&& isHoldingSpear()) {
                 justUnsheathed = false;
             }
         }
-
+        private bool isHoldingSpear() {
+            return EquipScript.getRight() == EquipType.Spear || EquipScript.getRight() == EquipType.SpearChitin;
+        }
         private bool isHoldingItem(bool isRightHand) {
             return isRightHand && getPlayerCharacter().GetRightItem() != null
                    || !isRightHand && getPlayerCharacter().GetLeftItem() != null;


### PR DESCRIPTION
- Change Quickmenu to follow position of the player, but not the head rotation
- Add Quickmenu angle to configuration