### PR TITLE
Allow fine control on the split menu slider

### DIFF
--- a/ValheimVRMod/Patches/ControlPatches.cs
+++ b/ValheimVRMod/Patches/ControlPatches.cs
@@ -370,6 +370,16 @@ namespace ValheimVRMod.Patches {
         }
     }
 
+    
+    // Used to make stack splitting easier
+    [HarmonyPatch(typeof(InventoryGui), "Awake")]
+    class InventoryGui_Awake_Patch {
+        static void Prefix(InventoryGui __instance)
+        {
+            __instance.m_splitSlider.gameObject.AddComponent<SliderSelector>();
+        }
+    }
+
     // Used to enable stack splitting in inventory
     [HarmonyPatch(typeof(InventoryGrid), "OnLeftClick")]
     class InventoryGrid_OnLeftClick_Patch {

--- a/ValheimVRMod/VRCore/UI/SliderSelector.cs
+++ b/ValheimVRMod/VRCore/UI/SliderSelector.cs
@@ -28,23 +28,26 @@ namespace ValheimVRMod.VRCore.UI
 
         private void Update() 
         {
-            float axisValue = VRControls.instance.GetJoyRightStickX();
-            if(Mathf.Abs(axisValue) > SLIDER_DEADZONE)
+            if(VRControls.mainControlsActive)
             {
-                if(_doSliderMovementDelayed == null)
+                float axisValue = VRControls.instance.GetJoyRightStickX();
+                if(Mathf.Abs(axisValue) > SLIDER_DEADZONE)
                 {
-                    float sign = Mathf.Sign(axisValue);
-                    float delay = _cumulativeDirection != 0 ? SLIDER_COOLDOWN / Mathf.Abs(_cumulativeDirection): 0;
-                    StartCoroutine((_doSliderMovementDelayed = DoSliderMovement(delay, sign)));
+                    if(_doSliderMovementDelayed == null)
+                    {
+                        float sign = Mathf.Sign(axisValue);
+                        float delay = _cumulativeDirection != 0 ? SLIDER_COOLDOWN / Mathf.Abs(_cumulativeDirection): 0;
+                        StartCoroutine((_doSliderMovementDelayed = DoSliderMovement(delay, sign)));
+                    }
                 }
+                else if(_doSliderMovementDelayed != null)
+                {
+                    _cumulativeDirection = 0;
+                    StopCoroutine(_doSliderMovementDelayed);
+                    _doSliderMovementDelayed = null;
+                }
+                else _cumulativeDirection = 0;
             }
-            else if(_doSliderMovementDelayed != null)
-            {
-                _cumulativeDirection = 0;
-                StopCoroutine(_doSliderMovementDelayed);
-                _doSliderMovementDelayed = null;
-            }
-            else _cumulativeDirection = 0;
         }
 
         private IEnumerator DoSliderMovement(float delay, float direction)

--- a/ValheimVRMod/VRCore/UI/SliderSelector.cs
+++ b/ValheimVRMod/VRCore/UI/SliderSelector.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.UI;
+using ValheimVRMod.Utilities;
+
+namespace ValheimVRMod.VRCore.UI
+{
+    public class SliderSelector : MonoBehaviour 
+    {
+        private const float SLIDER_DEADZONE = 0.5f;
+        private const float SLIDER_COOLDOWN = 0.4f;
+        private Slider _splitSlider;
+        private IEnumerator _doSliderMovementDelayed;
+        private int _cumulativeDirection = 0;
+        
+        private void Awake() 
+        {
+            _splitSlider = GetComponent<Slider>();
+        }
+
+        private void OnDisable() 
+        {
+            StopAllCoroutines();
+        }
+
+        private void Update() 
+        {
+            float axisValue = VRControls.instance.GetJoyRightStickX();
+            if(Mathf.Abs(axisValue) > SLIDER_DEADZONE)
+            {
+                if(_doSliderMovementDelayed == null)
+                {
+                    float sign = Mathf.Sign(axisValue);
+                    float delay = _cumulativeDirection != 0 ? SLIDER_COOLDOWN / Mathf.Abs(_cumulativeDirection): 0;
+                    StartCoroutine((_doSliderMovementDelayed = DoSliderMovement(delay, sign)));
+                }
+            }
+            else if(_doSliderMovementDelayed != null)
+            {
+                _cumulativeDirection = 0;
+                StopCoroutine(_doSliderMovementDelayed);
+                _doSliderMovementDelayed = null;
+            }
+            else _cumulativeDirection = 0;
+        }
+
+        private IEnumerator DoSliderMovement(float delay, float direction)
+        {
+            yield return new WaitForSeconds(delay);
+            if(Mathf.Sign(direction) != Mathf.Sign(_cumulativeDirection)) _cumulativeDirection = 0;
+            var newValue = (_splitSlider.value + direction) % _splitSlider.maxValue;
+            newValue = newValue >= _splitSlider.minValue ? newValue : _splitSlider.maxValue;
+            _splitSlider.value = newValue;
+            _cumulativeDirection += (int)direction;
+            _doSliderMovementDelayed = null;
+        }
+    }
+}

--- a/ValheimVRMod/ValheimVRMod.csproj
+++ b/ValheimVRMod/ValheimVRMod.csproj
@@ -340,6 +340,7 @@
     <Compile Include="VRCore\UI\EnemyHudManager.cs" />
     <Compile Include="VRCore\UI\PlaceModeRayVectorProvider.cs" />
     <Compile Include="VRCore\UI\RepairModePositionIndicator.cs" />
+    <Compile Include="VRCore\UI\SliderSelector.cs" />
     <Compile Include="VRCore\UI\SoftwareCursor.cs" />
     <Compile Include="VRCore\UI\VRControls.cs" />
     <Compile Include="VRCore\UI\VRGUI.cs" />


### PR DESCRIPTION
This adds the ability to use the right stick X axis to move the slider in the split stack screen, usefull to have more fine control on the split size