### PR TITLE
Vive wands fixes

### DIFF
--- a/Unity/ValheimVR/Assets/SteamVR_Input/ActionSetClasses/SteamVR_Input_ActionSet_LaserPointers.cs
+++ b/Unity/ValheimVR/Assets/SteamVR_Input/ActionSetClasses/SteamVR_Input_ActionSet_LaserPointers.cs
@@ -40,5 +40,21 @@ namespace Valve.VR
                 return SteamVR_Actions.laserPointers_ClickModifier;
             }
         }
+        
+        public virtual SteamVR_Action_Boolean Jump
+        {
+            get
+            {
+                return SteamVR_Actions.laserPointers_Jump;
+            }
+        }
+        
+        public virtual SteamVR_Action_Vector2 PitchAndYaw
+        {
+            get
+            {
+                return SteamVR_Actions.laserPointers_PitchAndYaw;
+            }
+        }
     }
 }

--- a/Unity/ValheimVR/Assets/SteamVR_Input/SteamVR_Input_Actions.cs
+++ b/Unity/ValheimVR/Assets/SteamVR_Input/SteamVR_Input_Actions.cs
@@ -83,6 +83,10 @@ namespace Valve.VR
         
         private static SteamVR_Action_Boolean p_laserPointers_ClickModifier;
         
+        private static SteamVR_Action_Boolean p_laserPointers_Jump;
+        
+        private static SteamVR_Action_Vector2 p_laserPointers_PitchAndYaw;
+        
         public static SteamVR_Action_Boolean default_InteractUI
         {
             get
@@ -347,6 +351,22 @@ namespace Valve.VR
             }
         }
         
+        public static SteamVR_Action_Boolean laserPointers_Jump
+        {
+            get
+            {
+                return SteamVR_Actions.p_laserPointers_Jump.GetCopy<SteamVR_Action_Boolean>();
+            }
+        }
+        
+        public static SteamVR_Action_Vector2 laserPointers_PitchAndYaw
+        {
+            get
+            {
+                return SteamVR_Actions.p_laserPointers_PitchAndYaw.GetCopy<SteamVR_Action_Vector2>();
+            }
+        }
+        
         private static void InitializeActionArrays()
         {
             Valve.VR.SteamVR_Input.actions = new Valve.VR.SteamVR_Action[] {
@@ -382,7 +402,9 @@ namespace Valve.VR
                     SteamVR_Actions.valheim_Haptic,
                     SteamVR_Actions.laserPointers_LeftClick,
                     SteamVR_Actions.laserPointers_RightClick,
-                    SteamVR_Actions.laserPointers_ClickModifier};
+                    SteamVR_Actions.laserPointers_ClickModifier,
+                    SteamVR_Actions.laserPointers_Jump,
+                    SteamVR_Actions.laserPointers_PitchAndYaw};
             Valve.VR.SteamVR_Input.actionsIn = new Valve.VR.ISteamVR_Action_In[] {
                     SteamVR_Actions.default_InteractUI,
                     SteamVR_Actions.default_Teleport,
@@ -414,7 +436,9 @@ namespace Valve.VR
                     SteamVR_Actions.valheim_QuickActions,
                     SteamVR_Actions.laserPointers_LeftClick,
                     SteamVR_Actions.laserPointers_RightClick,
-                    SteamVR_Actions.laserPointers_ClickModifier};
+                    SteamVR_Actions.laserPointers_ClickModifier,
+                    SteamVR_Actions.laserPointers_Jump,
+                    SteamVR_Actions.laserPointers_PitchAndYaw};
             Valve.VR.SteamVR_Input.actionsOut = new Valve.VR.ISteamVR_Action_Out[] {
                     SteamVR_Actions.default_Haptic,
                     SteamVR_Actions.valheim_Haptic};
@@ -446,14 +470,16 @@ namespace Valve.VR
                     SteamVR_Actions.valheim_QuickActions,
                     SteamVR_Actions.laserPointers_LeftClick,
                     SteamVR_Actions.laserPointers_RightClick,
-                    SteamVR_Actions.laserPointers_ClickModifier};
+                    SteamVR_Actions.laserPointers_ClickModifier,
+                    SteamVR_Actions.laserPointers_Jump};
             Valve.VR.SteamVR_Input.actionsSingle = new Valve.VR.SteamVR_Action_Single[] {
                     SteamVR_Actions.default_Squeeze};
             Valve.VR.SteamVR_Input.actionsVector2 = new Valve.VR.SteamVR_Action_Vector2[] {
                     SteamVR_Actions.valheim_PitchAndYaw,
                     SteamVR_Actions.valheim_HotbarScroll,
                     SteamVR_Actions.valheim_ContextScroll,
-                    SteamVR_Actions.valheim_Walk};
+                    SteamVR_Actions.valheim_Walk,
+                    SteamVR_Actions.laserPointers_PitchAndYaw};
             Valve.VR.SteamVR_Input.actionsVector3 = new Valve.VR.SteamVR_Action_Vector3[0];
             Valve.VR.SteamVR_Input.actionsSkeleton = new Valve.VR.SteamVR_Action_Skeleton[] {
                     SteamVR_Actions.default_SkeletonLeftHand,
@@ -484,7 +510,9 @@ namespace Valve.VR
                     SteamVR_Actions.valheim_QuickActions,
                     SteamVR_Actions.laserPointers_LeftClick,
                     SteamVR_Actions.laserPointers_RightClick,
-                    SteamVR_Actions.laserPointers_ClickModifier};
+                    SteamVR_Actions.laserPointers_ClickModifier,
+                    SteamVR_Actions.laserPointers_Jump,
+                    SteamVR_Actions.laserPointers_PitchAndYaw};
         }
         
         private static void PreInitActions()
@@ -522,6 +550,8 @@ namespace Valve.VR
             SteamVR_Actions.p_laserPointers_LeftClick = ((SteamVR_Action_Boolean)(SteamVR_Action.Create<SteamVR_Action_Boolean>("/actions/LaserPointers/in/LeftClick")));
             SteamVR_Actions.p_laserPointers_RightClick = ((SteamVR_Action_Boolean)(SteamVR_Action.Create<SteamVR_Action_Boolean>("/actions/LaserPointers/in/RightClick")));
             SteamVR_Actions.p_laserPointers_ClickModifier = ((SteamVR_Action_Boolean)(SteamVR_Action.Create<SteamVR_Action_Boolean>("/actions/LaserPointers/in/ClickModifier")));
+            SteamVR_Actions.p_laserPointers_Jump = ((SteamVR_Action_Boolean)(SteamVR_Action.Create<SteamVR_Action_Boolean>("/actions/LaserPointers/in/Jump")));
+            SteamVR_Actions.p_laserPointers_PitchAndYaw = ((SteamVR_Action_Vector2)(SteamVR_Action.Create<SteamVR_Action_Vector2>("/actions/LaserPointers/in/PitchAndYaw")));
         }
     }
 }

--- a/Unity/ValheimVR/Assets/StreamingAssets/SteamVR/actions.json
+++ b/Unity/ValheimVR/Assets/StreamingAssets/SteamVR/actions.json
@@ -161,6 +161,16 @@
       "name": "/actions/LaserPointers/in/ClickModifier",
       "type": "boolean",
       "requirement": "optional"
+    },
+    {
+      "name": "/actions/LaserPointers/in/Jump",
+      "type": "boolean",
+      "requirement": "optional"
+    },
+    {
+      "name": "/actions/LaserPointers/in/PitchAndYaw",
+      "type": "vector2",
+      "requirement": "optional"
     }
   ],
   "action_sets": [

--- a/Unity/ValheimVR/Assets/StreamingAssets/SteamVR/bindings_vive_controller.json
+++ b/Unity/ValheimVR/Assets/StreamingAssets/SteamVR/bindings_vive_controller.json
@@ -206,20 +206,35 @@
             {
                "inputs" : {
                   "click" : {
-                     "output" : "/actions/laserpointers/in/rightclick"
-                  }
-               },
-               "mode" : "trackpad",
-               "path" : "/user/hand/right/input/trackpad"
-            },
-            {
-               "inputs" : {
-                  "click" : {
                      "output" : "/actions/laserpointers/in/clickmodifier"
                   }
                },
                "mode" : "button",
                "path" : "/user/hand/left/input/trigger"
+            },
+            {
+               "inputs" : {
+                  "north" : {
+                     "output" : "/actions/laserpointers/in/jump"
+                  },
+                  "south" : {
+                     "output" : "/actions/laserpointers/in/rightclick"
+                  }
+               },
+               "mode" : "dpad",
+               "parameters" : {
+                  "sub_mode" : "click"
+               },
+               "path" : "/user/hand/right/input/trackpad"
+            },
+            {
+               "inputs" : {
+                  "position" : {
+                     "output" : "/actions/laserpointers/in/pitchandyaw"
+                  }
+               },
+               "mode" : "trackpad",
+               "path" : "/user/hand/right/input/trackpad"
             }
          ]
       },
@@ -231,32 +246,20 @@
          "sources" : []
       },
       "/actions/valheim" : {
-         "chords": [
+         "chords" : [
             {
-               "output": "/actions/valheim/in/togglemenu",
-               "inputs": [
-                  [
-                     "/user/hand/right/input/application_menu",
-                     "click"
-                  ],
-                  [
-                     "/user/hand/right/input/grip",
-                     "click"
-                  ]
-               ]
+               "inputs" : [
+                  [ "/user/hand/right/input/application_menu", "click" ],
+                  [ "/user/hand/right/input/grip", "click" ]
+               ],
+               "output" : "/actions/valheim/in/togglemenu"
             },
             {
-               "output": "/actions/valheim/in/togglemap",
-               "inputs": [
-                  [
-                     "/user/hand/left/input/grip",
-                     "click"
-                  ],
-                  [
-                     "/user/hand/left/input/application_menu",
-                     "click"
-                  ]
-               ]
+               "inputs" : [
+                  [ "/user/hand/left/input/grip", "click" ],
+                  [ "/user/hand/left/input/application_menu", "click" ]
+               ],
+               "output" : "/actions/valheim/in/togglemap"
             }
          ],
          "haptics" : [

--- a/ValheimVRMod/VRCore/UI/VRControls.cs
+++ b/ValheimVRMod/VRCore/UI/VRControls.cs
@@ -6,12 +6,12 @@ using ValheimVRMod.Scripts;
 using ValheimVRMod.Utilities;
 
 using static ValheimVRMod.Utilities.LogUtils;
+using System.Linq;
 
 namespace ValheimVRMod.VRCore.UI
 {
     class VRControls : MonoBehaviour
     {
-
         // Time in seconds that Recenter pose must be held to recenter
         private static readonly float RECENTER_POSE_TIME = 3f;
         // Local Position relative to HMD that will trigger the Recenter action
@@ -29,10 +29,18 @@ namespace ValheimVRMod.VRCore.UI
         private HashSet<string> ignoredZInputs = new HashSet<string>();
         private SteamVR_ActionSet mainActionSet = SteamVR_Actions.Valheim;
         private SteamVR_ActionSet laserActionSet = SteamVR_Actions.LaserPointers;
-        private Dictionary<string, SteamVR_Action_Boolean> zInputToBooleanAction = new Dictionary<string, SteamVR_Action_Boolean>();
+
+        // Since some controllers have most actions on trackpads (Vive Wands),
+        // SteamVR as of 22/09/2021 will still disable all the actions bound to 
+        // a lower priority action set even if they are of a completely different type
+        // This means that we have to duplicate actions in some actionsets so zInputToBooleanAction
+        // should map to an array that is the conjunction of the same action in different actionsets
+        private Dictionary<string, SteamVR_Action_Boolean[]> zInputToBooleanAction = new Dictionary<string, SteamVR_Action_Boolean[]>();
 
         private SteamVR_Action_Vector2 walk;
         private SteamVR_Action_Vector2 pitchAndYaw;
+        private SteamVR_Action_Vector2 buildPitchAndYaw; //for the same logic as zInputToBooleanAction, this is needed for controllers that have multiple actionsets using the trackpad
+        private float combinedPitchAndYawX => buildPitchAndYaw.active ? buildPitchAndYaw.axis.x : pitchAndYaw.axis.x;
 
         private SteamVR_Action_Vector2 contextScroll;
 
@@ -198,7 +206,11 @@ namespace ValheimVRMod.VRCore.UI
             {
                 return false;
             }
-            if (zinput == "Jump" && shouldDisableJump())
+            if (zinput == "Jump" && shouldEnableRemove())
+            {
+                return false;
+            }
+            if (zinput == "Remove" && !shouldEnableRemove())
             {
                 return false;
             }
@@ -228,14 +240,14 @@ namespace ValheimVRMod.VRCore.UI
                     return false;
                 }
             }
-            SteamVR_Action_Boolean action;
+            SteamVR_Action_Boolean[] action;
             zInputToBooleanAction.TryGetValue(zinput, out action);
             if (action == null)
             {
                 LogWarning("Unmapped ZInput Key:" + zinput);
                 return false;
             }
-            return action.GetStateDown(SteamVR_Input_Sources.Any);
+            return action.Any(x => x.GetStateDown(SteamVR_Input_Sources.Any));
         }
 
         public bool GetButton(string zinput)
@@ -244,22 +256,26 @@ namespace ValheimVRMod.VRCore.UI
             {
                 return false;
             }
-            if (zinput == "Jump" && shouldDisableJump())
+            if (zinput == "Jump" && shouldEnableRemove())
             {
                 return false;
             }
-            if(zinput == "JoyAltPlace")
+            if (zinput == "Remove" && !shouldEnableRemove())
+            {
+                return false;
+            }
+            if (zinput == "JoyAltPlace")
             {
                 return CheckAltButton();
             }
-            SteamVR_Action_Boolean action;
+            SteamVR_Action_Boolean[] action;
             zInputToBooleanAction.TryGetValue(zinput, out action);
             if (action == null)
             {
                 LogWarning("Unmapped ZInput Key:" + zinput);
                 return false;
             }
-            return action.GetState(SteamVR_Input_Sources.Any);
+            return action.Any(x => x.GetState(SteamVR_Input_Sources.Any));
         }
 
         private bool CheckAltButton()
@@ -275,18 +291,22 @@ namespace ValheimVRMod.VRCore.UI
             {
                 return false;
             }
-            if (zinput == "Jump" && shouldDisableJump())
+            if (zinput == "Jump" && shouldEnableRemove())
             {
                 return false;
             }
-            SteamVR_Action_Boolean action;
+            if (zinput == "Remove" && !shouldEnableRemove())
+            {
+                return false;
+            }
+            SteamVR_Action_Boolean[] action;
             zInputToBooleanAction.TryGetValue(zinput, out action);
             if (action == null)
             {
                 LogWarning("Unmapped ZInput Key:" + zinput);
                 return false;
             }
-            return action.GetStateUp(SteamVR_Input_Sources.Any);
+            return action.Any(x => x.GetStateUp(SteamVR_Input_Sources.Any));
         }
 
         public float GetJoyLeftStickX()
@@ -314,7 +334,7 @@ namespace ValheimVRMod.VRCore.UI
             {
                 return 0.0f;
             }
-            return pitchAndYaw.axis.x;
+            return combinedPitchAndYawX;
         }
 
         public float GetJoyRightStickY()
@@ -371,7 +391,7 @@ namespace ValheimVRMod.VRCore.UI
                 return 0;
             }
             altPieceTriggered = false;
-            float rightStickXAxis = pitchAndYaw.axis.x;
+            float rightStickXAxis = combinedPitchAndYawX;
             if (rightStickXAxis > 0.1f)
             {
                 return -1;
@@ -424,29 +444,30 @@ namespace ValheimVRMod.VRCore.UI
 
         // disable Jump input under certain conditions
         // * In placement mode
-        private bool shouldDisableJump()
+        // * Grab Modifier is Pressed
+        private bool shouldEnableRemove()
         {
-            return inPlaceMode();
+            return inPlaceMode() && SteamVR_Actions.valheim_Grab.GetState(SteamVR_Input_Sources.RightHand);
         }
-
         private void init()
         {
-            zInputToBooleanAction.Add("JoyMenu", SteamVR_Actions.valheim_ToggleMenu);
-            zInputToBooleanAction.Add("Inventory", SteamVR_Actions.valheim_ToggleInventory);
-            zInputToBooleanAction.Add("Jump", SteamVR_Actions.valheim_Jump);
-            zInputToBooleanAction.Add("Use", SteamVR_Actions.valheim_Use);
-            zInputToBooleanAction.Add("Sit", SteamVR_Actions.valheim_Sit);
-            zInputToBooleanAction.Add("Map", SteamVR_Actions.valheim_ToggleMap);
+            zInputToBooleanAction.Add("JoyMenu", new[] { SteamVR_Actions.valheim_ToggleMenu });
+            zInputToBooleanAction.Add("Inventory", new[] { SteamVR_Actions.valheim_ToggleInventory });
+            zInputToBooleanAction.Add("Jump", new [] { SteamVR_Actions.valheim_Jump, SteamVR_Actions.laserPointers_Jump });
+            zInputToBooleanAction.Add("Use", new[] { SteamVR_Actions.valheim_Use });
+            zInputToBooleanAction.Add("Sit", new[] { SteamVR_Actions.valheim_Sit });
+            zInputToBooleanAction.Add("Map", new[] { SteamVR_Actions.valheim_ToggleMap });
 
             // These placement commands re-use some of the normal game inputs
-            zInputToBooleanAction.Add("BuildMenu", SteamVR_Actions.laserPointers_RightClick);
-            zInputToBooleanAction.Add("JoyPlace", SteamVR_Actions.laserPointers_LeftClick);
-            zInputToBooleanAction.Add("Remove", SteamVR_Actions.valheim_Jump);
+            zInputToBooleanAction.Add("BuildMenu", new[] { SteamVR_Actions.laserPointers_RightClick });
+            zInputToBooleanAction.Add("JoyPlace", new[] { SteamVR_Actions.laserPointers_LeftClick });
+            zInputToBooleanAction.Add("Remove", new[] { SteamVR_Actions.valheim_Jump, SteamVR_Actions.laserPointers_Jump });
 
             contextScroll = SteamVR_Actions.valheim_ContextScroll;
 
             walk = SteamVR_Actions.valheim_Walk;
             pitchAndYaw = SteamVR_Actions.valheim_PitchAndYaw;
+            buildPitchAndYaw = SteamVR_Actions.laserPointers_PitchAndYaw;
             poseL = SteamVR_Actions.valheim_PoseL;
             poseR = SteamVR_Actions.valheim_PoseR;
             initIgnoredZInputs();


### PR DESCRIPTION
- Allow wand users to jump/destroy items while in build mode (by pressing right trackpad north)
- Allow wand users to rotate while in build mode (only the X axis on the trackpad is used)
- Move Destroy action to require the grab modifier (this allows for jumping without destroying stuff in build mode)