### PR TITLE
Raise arrow rest

### DIFF
--- a/ValheimVRMod/Scripts/BowLocalManager.cs
+++ b/ValheimVRMod/Scripts/BowLocalManager.cs
@@ -133,7 +133,7 @@ namespace ValheimVRMod.Scripts {
 
             float stepLength = 0.1f;
             float stepSize = 20;
-            Vector3 pos = arrowRest.transform.position;
+            Vector3 pos = getArrowRestPosition();
             List<Vector3> pointList = new List<Vector3>();
 
             for (int i = 0; i < stepSize; i++) {
@@ -144,6 +144,10 @@ namespace ValheimVRMod.Scripts {
 
             predictionLine.positionCount = 20;
             predictionLine.SetPositions(pointList.ToArray());
+        }
+
+        private Vector3 getArrowRestPosition() {
+            return transform.position - transform.up * VHVRConfig.ArrowRestElevation();
         }
 
         private void handlePulling() {

--- a/ValheimVRMod/Scripts/BowLocalManager.cs
+++ b/ValheimVRMod/Scripts/BowLocalManager.cs
@@ -133,7 +133,7 @@ namespace ValheimVRMod.Scripts {
 
             float stepLength = 0.1f;
             float stepSize = 20;
-            Vector3 pos = getArrowRestPosition();
+            Vector3 pos = arrowRest.transform.position;
             List<Vector3> pointList = new List<Vector3>();
 
             for (int i = 0; i < stepSize; i++) {

--- a/ValheimVRMod/Scripts/BowLocalManager.cs
+++ b/ValheimVRMod/Scripts/BowLocalManager.cs
@@ -146,10 +146,6 @@ namespace ValheimVRMod.Scripts {
             predictionLine.SetPositions(pointList.ToArray());
         }
 
-        private Vector3 getArrowRestPosition() {
-            return transform.position - transform.up * VHVRConfig.ArrowOffsetDistance();
-        }
-
         private void handlePulling() {
             if (!pulling && !checkHandNearString()) {
                 return;

--- a/ValheimVRMod/Scripts/BowLocalManager.cs
+++ b/ValheimVRMod/Scripts/BowLocalManager.cs
@@ -145,11 +145,6 @@ namespace ValheimVRMod.Scripts {
             predictionLine.positionCount = 20;
             predictionLine.SetPositions(pointList.ToArray());
         }
-
-        private Vector3 getArrowRestPosition() {
-            return transform.position - transform.up * VHVRConfig.ArrowRestElevation();
-        }
-
         private void handlePulling() {
             if (!pulling && !checkHandNearString()) {
                 return;
@@ -162,7 +157,7 @@ namespace ValheimVRMod.Scripts {
             
             arrowAttach.transform.rotation = pullObj.transform.rotation;
             arrowAttach.transform.position = pullObj.transform.position;
-            spawnPoint = transform.position;
+            spawnPoint = getArrowRestPosition();
             aimDir = -transform.forward;
             var currDrawPercentage = pullPercentage();
             if (arrow != null) {
@@ -179,7 +174,7 @@ namespace ValheimVRMod.Scripts {
             predictionLine.enabled = false;
             pulling = isPulling = false;
             attackDrawPercentage = pullPercentage();
-            spawnPoint = transform.position;
+            spawnPoint = getArrowRestPosition();
             aimDir = -transform.forward;
 
             if (withoutShoot || arrow == null || attackDrawPercentage <= 0.0f) {
@@ -268,9 +263,15 @@ namespace ValheimVRMod.Scripts {
 
             return null;
         }
-        
+
+        private Vector3 getArrowRestPosition()
+        {
+            return transform.position - transform.up * VHVRConfig.ArrowRestElevation();
+        }
+
         public bool isHoldingArrow() {
             return arrow != null;
         }
+
     }
 }

--- a/ValheimVRMod/Scripts/BowLocalManager.cs
+++ b/ValheimVRMod/Scripts/BowLocalManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Rendering;
 using ValheimVRMod.Utilities;
@@ -133,7 +133,7 @@ namespace ValheimVRMod.Scripts {
 
             float stepLength = 0.1f;
             float stepSize = 20;
-            Vector3 pos = transform.position;
+            Vector3 pos = getArrowRestPosition();
             List<Vector3> pointList = new List<Vector3>();
 
             for (int i = 0; i < stepSize; i++) {
@@ -144,6 +144,10 @@ namespace ValheimVRMod.Scripts {
 
             predictionLine.positionCount = 20;
             predictionLine.SetPositions(pointList.ToArray());
+        }
+
+        private Vector3 getArrowRestPosition() {
+            return transform.position - transform.up * VHVRConfig.ArrowOffsetDistance();
         }
 
         private void handlePulling() {

--- a/ValheimVRMod/Scripts/BowManager.cs
+++ b/ValheimVRMod/Scripts/BowManager.cs
@@ -156,7 +156,6 @@ namespace ValheimVRMod.Scripts {
                 pullObj.transform.localPosition = new Vector3(pullPos.x, pullPos.y, pullStart.z);
             }
 
-            // pushObj.transform.position = transform.position;
             pushObj.transform.LookAt(pullObj.transform, worldUp: -transform.parent.forward);
         }
     }

--- a/ValheimVRMod/Scripts/BowManager.cs
+++ b/ValheimVRMod/Scripts/BowManager.cs
@@ -15,7 +15,7 @@ namespace ValheimVRMod.Scripts {
         protected Vector3 stringBottom;
         protected Vector3 pullStart;
         protected GameObject pullObj;
-        protected GameObject stringCenter;
+        protected GameObject arrowRest;
         protected Quaternion originalRotation;
         protected bool initialized;
         protected bool wasInitialized;
@@ -39,13 +39,12 @@ namespace ValheimVRMod.Scripts {
             pullObj.transform.SetParent(transform, false);
             pullObj.transform.forward *= -1;
 
-            stringCenter = new GameObject();
-            stringCenter.transform.SetParent(transform, false);
+            arrowRest = new GameObject();
         }
 
         protected void OnDestroy() {
             Destroy(pullObj);
-            Destroy(stringCenter);
+            Destroy(arrowRest);
         }
 
         /**
@@ -124,8 +123,8 @@ namespace ValheimVRMod.Scripts {
 
                 pullString();
                 gameObject.GetComponent<LineRenderer>().SetPosition(1, pullObj.transform.localPosition);
-                updateStringCenter();
-                transform.LookAt(stringCenter.transform, -transform.parent.forward);
+                udpateArrowRest();
+                transform.rotation = arrowRest.transform.rotation;
 
             } else if (wasPulling) {
                 wasPulling = false;
@@ -135,12 +134,19 @@ namespace ValheimVRMod.Scripts {
             }
 
         }
-        private void updateStringCenter() {
+
+        private void udpateArrowRest() {
+            arrowRest.transform.position = transform.position + getArrowRestOffset();
+            arrowRest.transform.LookAt(pullObj.transform, -transform.parent.forward);
+        }
+
+        private Vector3 getArrowRestOffset() {
             Vector3 drawVector = pullObj.transform.position - transform.position;
             float drawLength = drawVector.magnitude;
-            float nockOffsetAmount = drawLength * (float)Math.Tan(Math.Asin(Math.Min(VHVRConfig.ArrowOffsetDistance() / drawVector.magnitude, 0.9)));
-            Vector3 nockOffsetDir = Vector3.Normalize(transform.parent.forward - Vector3.Project(transform.parent.forward, drawVector));
-            stringCenter.transform.position = pullObj.transform.position - nockOffsetDir * nockOffsetAmount;
+            double arrowOffsetAngle = Math.Asin(VHVRConfig.ArrowOffsetDistance() / drawVector.magnitude);
+            float tanArrowOffset = (float) Math.Tan(arrowOffsetAngle);
+            Vector3 upwardPerpendicularToDraw = Vector3.Normalize(transform.parent.forward - Vector3.Project(transform.parent.forward, drawVector));
+            return Vector3.Lerp(upwardPerpendicularToDraw * drawLength * tanArrowOffset, drawVector, tanArrowOffset * tanArrowOffset);
         }
 
         private void pullString() {

--- a/ValheimVRMod/Scripts/BowManager.cs
+++ b/ValheimVRMod/Scripts/BowManager.cs
@@ -143,7 +143,7 @@ namespace ValheimVRMod.Scripts {
         private Vector3 getArrowRestOffset() {
             Vector3 drawVector = pullObj.transform.position - transform.position;
 
-            // The angle between the push directioin and the arrow direction.
+            // The angle between the push direction and the arrow direction.
             double pushOffsetAngle = Math.Asin(VHVRConfig.ArrowRestElevation() / drawVector.magnitude);
 
             // A vector that lies on the bow surface and is perpendicular to the draw direction.

--- a/ValheimVRMod/Scripts/BowManager.cs
+++ b/ValheimVRMod/Scripts/BowManager.cs
@@ -81,7 +81,7 @@ namespace ValheimVRMod.Scripts {
                 }
             }
             
-            pullStart = Vector3.Lerp(stringTop, stringBottom, 0.5f) - transform.up * VHVRConfig.ArrowOffsetDistance();
+            pullStart = Vector3.Lerp(stringTop, stringBottom, 0.5f);
             initialized = true;
         }
 

--- a/ValheimVRMod/Scripts/BowManager.cs
+++ b/ValheimVRMod/Scripts/BowManager.cs
@@ -81,7 +81,7 @@ namespace ValheimVRMod.Scripts {
                     }
                 }
             }
-            
+
             pullStart = Vector3.Lerp(stringTop, stringBottom, 0.5f);
             initialized = true;
         }
@@ -125,6 +125,7 @@ namespace ValheimVRMod.Scripts {
                 pullString();
                 gameObject.GetComponent<LineRenderer>().SetPosition(1, pullObj.transform.localPosition);
                 rotateBowOnPulling();
+
             } else if (wasPulling) {
                 wasPulling = false;
                 pullObj.transform.localPosition = pullStart;
@@ -140,7 +141,11 @@ namespace ValheimVRMod.Scripts {
             // The angle between the push direction and the arrow direction.
             double pushOffsetAngle = Math.Asin(VHVRConfig.ArrowRestElevation() / drawLength);
 
-            transform.rotation = pushObj.transform.rotation * Quaternion.Euler((float) (-pushOffsetAngle * (180.0 / Math.PI)), 0, 0);
+            // Align the z-axis of the pushObj with the direction of the draw force and determine its y-axis using the orientation of the bow hand.
+            pushObj.transform.LookAt(pullObj.transform, worldUp: -transform.parent.forward);
+
+            // Assuming that the bow is perpendicular to the arrow, the angle between the y-axis of the bow and the y-axis of the pushObj should also be pushOffsetAngle.
+            transform.rotation = pushObj.transform.rotation * Quaternion.AngleAxis((float) (-pushOffsetAngle * (180.0 / Math.PI)), Vector3.right);
         }
 
         private void pullString() {
@@ -155,8 +160,6 @@ namespace ValheimVRMod.Scripts {
             if (pullPos.z < pullStart.z) {
                 pullObj.transform.localPosition = new Vector3(pullPos.x, pullPos.y, pullStart.z);
             }
-
-            pushObj.transform.LookAt(pullObj.transform, worldUp: -transform.parent.forward);
         }
     }
 }

--- a/ValheimVRMod/Scripts/BowManager.cs
+++ b/ValheimVRMod/Scripts/BowManager.cs
@@ -142,11 +142,15 @@ namespace ValheimVRMod.Scripts {
 
         private Vector3 getArrowRestOffset() {
             Vector3 drawVector = pullObj.transform.position - transform.position;
-            float drawLength = drawVector.magnitude;
-            double arrowOffsetAngle = Math.Asin(VHVRConfig.ArrowOffsetDistance() / drawVector.magnitude);
-            float tanArrowOffset = (float) Math.Tan(arrowOffsetAngle);
-            Vector3 upwardPerpendicularToDraw = Vector3.Normalize(transform.parent.forward - Vector3.Project(transform.parent.forward, drawVector));
-            return Vector3.Lerp(upwardPerpendicularToDraw * drawLength * tanArrowOffset, drawVector, tanArrowOffset * tanArrowOffset);
+
+            // The angle between the push directioin and the arrow direction.
+            double pushOffsetAngle = Math.Asin(VHVRConfig.ArrowRestElevation() / drawVector.magnitude);
+
+            // A vector that lies on the bow surface and is perpendicular to the draw direction.
+            Vector3 upwardPerpendicularToDraw = transform.parent.forward - Vector3.Project(transform.parent.forward, drawVector);
+
+            Vector3 arrowRestOffsetDir = Vector3.RotateTowards(upwardPerpendicularToDraw, target: drawVector, maxRadiansDelta: (float) pushOffsetAngle, maxMagnitudeDelta: 0);
+            return arrowRestOffsetDir.normalized * VHVRConfig.ArrowRestElevation();
         }
 
         private void pullString() {

--- a/ValheimVRMod/Utilities/VHVRConfig.cs
+++ b/ValheimVRMod/Utilities/VHVRConfig.cs
@@ -86,7 +86,7 @@ namespace ValheimVRMod.Utilities
         private static ConfigEntry<bool> useSpearDirectionGraphic;
         private static ConfigEntry<bool> spearThrowSpeedDynamic;
         private static ConfigEntry<bool> spearTwoHanded;
-        private static ConfigEntry<float> arrowOffsetDistance;
+        private static ConfigEntry<float> arrowRestElevation;
 
 #if DEBUG
         private static ConfigEntry<float> DebugPosX;
@@ -440,11 +440,11 @@ namespace ValheimVRMod.Utilities
                                                     "TwoHandedSpear",
                                                     false,
                                                     "Use this to toggle controls of two handed spear (left hand grab while having spear) (experimental)");
-            arrowOffsetDistance = config.Bind("Motion Control",
-                "ArrowOffsetDistance",
-                0.125f,
+            arrowRestElevation = config.Bind("Motion Control",
+                "ArrowRestElevation",
+                0.15f,
                 new ConfigDescription("The amount by which the arrow rest is higher than the center of the bow handle",
-                    new AcceptableValueRange<float>(0, 0.2f)));
+                    new AcceptableValueRange<float>(0, 0.5f)));
 
 // #if DEBUG
 //             DebugPosX = config.Bind("Motion Control",
@@ -721,9 +721,9 @@ namespace ValheimVRMod.Utilities
             return useArrowPredictionGraphic.Value;
         }
 
-        public static float ArrowOffsetDistance()
+        public static float ArrowRestElevation()
         {
-            return arrowOffsetDistance.Value;
+            return arrowRestElevation.Value;
         }
 
         public static bool NonVrPlayer()

--- a/ValheimVRMod/Utilities/VHVRConfig.cs
+++ b/ValheimVRMod/Utilities/VHVRConfig.cs
@@ -444,7 +444,7 @@ namespace ValheimVRMod.Utilities
                 "ArrowRestElevation",
                 0.15f,
                 new ConfigDescription("The amount by which the arrow rest is higher than the center of the bow handle",
-                    new AcceptableValueRange<float>(0, 0.5f)));
+                    new AcceptableValueRange<float>(0, 0.25f)));
 
 // #if DEBUG
 //             DebugPosX = config.Bind("Motion Control",

--- a/ValheimVRMod/Utilities/VHVRConfig.cs
+++ b/ValheimVRMod/Utilities/VHVRConfig.cs
@@ -443,7 +443,7 @@ namespace ValheimVRMod.Utilities
             arrowOffsetDistance = config.Bind("Motion Control",
                 "ArrowOffsetDistance",
                 0.125f,
-                new ConfigDescription("The distance by which the arrow rest is above the center of the bow handle",
+                new ConfigDescription("The amount by which the arrow rest is higher than the center of the bow handle",
                     new AcceptableValueRange<float>(0, 0.2f)));
 
 // #if DEBUG

--- a/ValheimVRMod/Utilities/VHVRConfig.cs
+++ b/ValheimVRMod/Utilities/VHVRConfig.cs
@@ -1,4 +1,4 @@
-﻿using BepInEx.Configuration;
+using BepInEx.Configuration;
 using Unity.XR.OpenVR;
 using System;
 using ValheimVRMod.VRCore;
@@ -86,6 +86,7 @@ namespace ValheimVRMod.Utilities
         private static ConfigEntry<bool> useSpearDirectionGraphic;
         private static ConfigEntry<bool> spearThrowSpeedDynamic;
         private static ConfigEntry<bool> spearTwoHanded;
+        private static ConfigEntry<float> arrowOffsetDistance;
 
 #if DEBUG
         private static ConfigEntry<float> DebugPosX;
@@ -439,6 +440,12 @@ namespace ValheimVRMod.Utilities
                                                     "TwoHandedSpear",
                                                     false,
                                                     "Use this to toggle controls of two handed spear (left hand grab while having spear) (experimental)");
+            arrowOffsetDistance = config.Bind("Motion Control",
+                "ArrowOffsetDistance",
+                0.125f,
+                new ConfigDescription("The distance by which the arrow rest is above the center of the bow handle",
+                    new AcceptableValueRange<float>(0, 0.2f)));
+
 // #if DEBUG
 //             DebugPosX = config.Bind("Motion Control",
 //                 "DebugPosX",
@@ -712,6 +719,11 @@ namespace ValheimVRMod.Utilities
         public static bool UseArrowPredictionGraphic()
         {
             return useArrowPredictionGraphic.Value;
+        }
+
+        public static float ArrowOffsetDistance()
+        {
+            return arrowOffsetDistance.Value;
         }
 
         public static bool NonVrPlayer()


### PR DESCRIPTION
Raise the arrow rest from the center of the bow handle to the top of the bow handle. This will make the shooting experience close to that IRL and increase the visibility of the arrow which is very important for instinctive aiming.

The arrow will stay perpendicular to the bow handle with this change. Since the arrow rest is no longer at the front hand pushing point (center of bow handle), the pushing direction will no longer be parallel to the arrow or perpendicular to the bow handle. Instead, it will be off the arrow by an angle of arcsin(arrowRestElevation / currentDrawLength).