### PR TITLE
Disable room scale movement when attached to seat, saddle, etc.

### DIFF
--- a/ValheimVRMod/VRCore/VRPlayer.cs
+++ b/ValheimVRMod/VRCore/VRPlayer.cs
@@ -927,7 +927,7 @@ namespace ValheimVRMod.VRCore
         void DoRoomScaleMovement()
         {
             var player = getPlayerCharacter();
-            if (player.IsSitting() || player.IsAttached()) {
+            if (player.IsAttached()) {
               return;
             }
             Vector3 deltaPosition = _vrCam.transform.localPosition - _lastCamPosition;

--- a/ValheimVRMod/VRCore/VRPlayer.cs
+++ b/ValheimVRMod/VRCore/VRPlayer.cs
@@ -927,7 +927,7 @@ namespace ValheimVRMod.VRCore
         void DoRoomScaleMovement()
         {
             var player = getPlayerCharacter();
-            if (player.isSitting()) {
+            if (player.IsSitting() || player.IsAttached()) {
               return;
             }
             Vector3 deltaPosition = _vrCam.transform.localPosition - _lastCamPosition;

--- a/ValheimVRMod/VRCore/VRPlayer.cs
+++ b/ValheimVRMod/VRCore/VRPlayer.cs
@@ -927,6 +927,9 @@ namespace ValheimVRMod.VRCore
         void DoRoomScaleMovement()
         {
             var player = getPlayerCharacter();
+            if (player.isSitting()) {
+              return;
+            }
             Vector3 deltaPosition = _vrCam.transform.localPosition - _lastCamPosition;
             deltaPosition.y = 0;
             bool shouldMove = deltaPosition.magnitude > 0.005f;


### PR DESCRIPTION
When the character is sitting on a chair, ship, or saddle or holdig onto the mast, disable room scale movement so that vr viewpoint can be moved freely to allow leaning.

In the above cases, the player is attached to an object so the roomscale movement logic does not cause locomotion but only forces the vrcam to be right above the seat. Skipping roomscale movement logic in these cases allows the player to lean. When steering a karve, this means that the player can lean left/right when looking back so that the tail of the boat does not block the hindsight.