### PR TITLE
Do not rotate view with lox when lox turns

### DIFF
--- a/ValheimVRMod/Patches/EyeRotationPatch.cs
+++ b/ValheimVRMod/Patches/EyeRotationPatch.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using UnityEngine;
 using ValheimVRMod.VRCore;
 using ValheimVRMod.Utilities;
@@ -33,12 +33,13 @@ namespace ValheimVRMod.Patches
                 !VRPlayer.attachedToPlayer ||
                 !VRPlayer.inFirstPerson ||
                 !VHVRConfig.UseLookLocomotion() ||
+                __instance.IsRiding() ||
                 ___m_currentStation != null /* Not Crafting */)
             {
                 return;
             }
 
-            /* Not attached to something, like boat controls */
+            /* Attached to something, like boat controls */
             if(__instance.IsAttached())
             {
                 //Apply ship rotation

--- a/ValheimVRMod/Patches/EyeRotationPatch.cs
+++ b/ValheimVRMod/Patches/EyeRotationPatch.cs
@@ -33,8 +33,12 @@ namespace ValheimVRMod.Patches
                 !VRPlayer.attachedToPlayer ||
                 !VRPlayer.inFirstPerson ||
                 !VHVRConfig.UseLookLocomotion() ||
-                __instance.IsRiding() ||
                 ___m_currentStation != null /* Not Crafting */)
+            {
+                return;
+            }
+
+            if (!VHVRConfig.TurnWithMountedAnimal() && __instance.IsRiding())
             {
                 return;
             }

--- a/ValheimVRMod/Patches/EyeRotationPatch.cs
+++ b/ValheimVRMod/Patches/EyeRotationPatch.cs
@@ -38,7 +38,7 @@ namespace ValheimVRMod.Patches
                 return;
             }
 
-            if (!VHVRConfig.TurnWithMountedAnimal() && __instance.IsRiding())
+            if (!VHVRConfig.ViewTurnWithMountedAnimal() && __instance.IsRiding())
             {
                 return;
             }

--- a/ValheimVRMod/Utilities/VHVRConfig.cs
+++ b/ValheimVRMod/Utilities/VHVRConfig.cs
@@ -73,6 +73,7 @@ namespace ValheimVRMod.Utilities
         private static ConfigEntry<float> altPieceRotationDelay;
         private static ConfigEntry<bool> runIsToggled;
         private static ConfigEntry<bool> leftHanded;
+        private static ConfigEntry<bool> turnWithMountedAnimal;
 
         // Graphics Settings
         private static ConfigEntry<bool> useAmplifyOcclusion;
@@ -350,6 +351,10 @@ namespace ValheimVRMod.Utilities
                 "Left Handed",
                 false,
                 "Left Handed Mode");
+            turnWithMountedAnimal = config.Bind("Controls",
+                                       "TurnWithMountedAnimal",
+                                       false,
+                                       "Whether the view turns automatically together with the mounted animal when the animal turns.");
             InitializeConfigurableKeyBindings(config);
         }
 
@@ -811,12 +816,17 @@ namespace ValheimVRMod.Utilities
         {
             return runIsToggled.Value;
         }
-        
+
         public static bool LeftHanded()
         {
             return leftHanded.Value;
         }
-        
+
+        public static bool TurnWithMountedAnimal()
+        {
+            return turnWithMountedAnimal.Value;
+        }
+
         public static float ArrowParticleSize()
         {
             return arrowParticleSize.Value;

--- a/ValheimVRMod/Utilities/VHVRConfig.cs
+++ b/ValheimVRMod/Utilities/VHVRConfig.cs
@@ -73,7 +73,7 @@ namespace ValheimVRMod.Utilities
         private static ConfigEntry<float> altPieceRotationDelay;
         private static ConfigEntry<bool> runIsToggled;
         private static ConfigEntry<bool> leftHanded;
-        private static ConfigEntry<bool> turnWithMountedAnimal;
+        private static ConfigEntry<bool> viewTurnWithMountedAnimal;
 
         // Graphics Settings
         private static ConfigEntry<bool> useAmplifyOcclusion;
@@ -351,8 +351,8 @@ namespace ValheimVRMod.Utilities
                 "Left Handed",
                 false,
                 "Left Handed Mode");
-            turnWithMountedAnimal = config.Bind("Controls",
-                                       "TurnWithMountedAnimal",
+            viewTurnWithMountedAnimal = config.Bind("Controls",
+                                       "ViewTurnWithMountedAnimal",
                                        false,
                                        "Whether the view turns automatically together with the mounted animal when the animal turns.");
             InitializeConfigurableKeyBindings(config);
@@ -822,9 +822,9 @@ namespace ValheimVRMod.Utilities
             return leftHanded.Value;
         }
 
-        public static bool TurnWithMountedAnimal()
+        public static bool ViewTurnWithMountedAnimal()
         {
-            return turnWithMountedAnimal.Value;
+            return viewTurnWithMountedAnimal.Value;
         }
 
         public static float ArrowParticleSize()


### PR DESCRIPTION
Provide an option to have the vr cam not rotating with the mounted animal when riding. This can 1) make lox control closer to that on vanilla game and 2) prevent unwanted smooth turn during riding for players who use snap turns.