### PR TITLE
Minor cleanup and QoL tweaks in bow work

### DIFF
--- a/ValheimVRMod/Patches/BowAndFishingPatches.cs
+++ b/ValheimVRMod/Patches/BowAndFishingPatches.cs
@@ -21,7 +21,7 @@ namespace ValheimVRMod.Patches {
             }
 
             if (EquipScript.getLeft() == EquipType.Bow && !VHVRConfig.RestrictBowDrawSpeed()) {
-                __result = BowLocalManager.attackDrawPercentage;
+                __result = BowLocalManager.realLifePullPercentage;
                 return false;
             }
 

--- a/ValheimVRMod/Scripts/BowLocalManager.cs
+++ b/ValheimVRMod/Scripts/BowLocalManager.cs
@@ -58,7 +58,7 @@ namespace ValheimVRMod.Scripts {
             outline.enabled = false;
 
             vrikHandConnector = new GameObject();
-            vrikHandConnector.transform.SetParent(VRPlayer.rightHand.transform, false);
+            vrikHandConnector.transform.SetParent(mainHand, false);
             
             item = Player.m_localPlayer.GetLeftItem();
             if (item != null) {
@@ -208,7 +208,7 @@ namespace ValheimVRMod.Scripts {
                 return;
             }
 
-            VRPlayer.vrikRef.solver.rightArm.target.SetParent(VRPlayer.rightHand.transform, false);
+            (VHVRConfig.LeftHanded() ? VRPlayer.vrikRef.solver.leftArm : VRPlayer.vrikRef.solver.rightArm).target.SetParent(mainHand, false);
             
             predictionLine.enabled = false;
             pulling = isPulling = false;
@@ -251,7 +251,7 @@ namespace ValheimVRMod.Scripts {
                 attackDrawPercentage = 0;
             }
             
-            VRPlayer.vrikRef.solver.rightArm.target.SetParent(vrikHandConnector.transform, false);
+            (VHVRConfig.LeftHanded() ? VRPlayer.vrikRef.solver.leftArm : VRPlayer.vrikRef.solver.rightArm).target.SetParent(vrikHandConnector.transform, false);
 
             return pulling = true;
         }

--- a/ValheimVRMod/Scripts/BowManager.cs
+++ b/ValheimVRMod/Scripts/BowManager.cs
@@ -13,7 +13,6 @@ namespace ValheimVRMod.Scripts {
         public static float realLifePullPercentage;
 
         protected const float maxPullLength = 0.6f;
-        protected float chargedPullLength = maxPullLength;
         protected Vector3 stringTop;
         protected Vector3 stringBottom;
         protected Vector3 pullStart;
@@ -155,10 +154,13 @@ namespace ValheimVRMod.Scripts {
 
             pullObj.transform.position = mainHand.position;
             var pullPos = pullObj.transform.localPosition;
-            realLifePullPercentage = Math.Min(Math.Max(pullPos.z - pullStart.z, 0) / (maxPullLength - pullStart.z), 1);
+            realLifePullPercentage = Mathf.Pow(Math.Min(Math.Max(pullPos.z - pullStart.z, 0) / (maxPullLength - pullStart.z), 1), 2);
 
-            if (pullPos.z > chargedPullLength) {
-                pullObj.transform.localPosition = new Vector3(pullPos.x, pullPos.y, chargedPullLength);
+            // If RestrictBowDrawSpeed is enabled, limit the vr pull length by the square root of the current attack draw percentage to simulate the resistance.
+            float pullLengthRestriction = VHVRConfig.RestrictBowDrawSpeed() ? Mathf.Lerp(pullStart.z, maxPullLength, Math.Max(Mathf.Sqrt(Player.m_localPlayer.GetAttackDrawPercentage()), 0.01f)) : maxPullLength;
+
+            if (pullPos.z > pullLengthRestriction) {
+                pullObj.transform.localPosition = new Vector3(pullPos.x, pullPos.y, pullLengthRestriction);
             }
 
             if (pullPos.z < pullStart.z) {


### PR DESCRIPTION
**Minor refactoring to improve code simplicity and readability (no change in behavior expected):**
- When patching AttackDrawPercentage for bows when RestrictBowDrawSpeed is off, use realLifePullPercentage instead of BowLocalManager.attackDrawPercentage. Change attackDrawPercentage into a private field accordingly.
- Remove chargePullLength from BowManager since it is used in only one place where it can be calculated locally.
- Reuse realLifePullPercentage and Player.m_localPlayer.GetAttackDrawPercentage() to calculate current pullPercentage.

**QoL tweaks:**
- Since we fall back to vanilla logic for draw speed when RestrictBowDrawSpeed is on now, we can completely disable custom code for additional stamina drain in that case instead of using the smaller number 3.
- Make attack draw percentage quadratic instead of linear to draw length so that the bow functions and feels more realistic - for example, the draw feels harder as the draw length increases.
- In addition to arrow hand haptic feedback, apply haptic feedback to the bow hand as well to simulate bow vibration upon arrow release.