### PR TITLE
Keep the character head rotation in sync with the vr look direction when riding lox

### DIFF
--- a/ValheimVRMod/Patches/EyeRotationPatch.cs
+++ b/ValheimVRMod/Patches/EyeRotationPatch.cs
@@ -38,13 +38,8 @@ namespace ValheimVRMod.Patches
                 return;
             }
 
-            if (!VHVRConfig.ViewTurnWithMountedAnimal() && __instance.IsRiding())
-            {
-                return;
-            }
-
             /* Attached to something, like boat controls */
-            if(__instance.IsAttached())
+            if(__instance.IsAttached() && (VHVRConfig.ViewTurnWithMountedAnimal() || !__instance.IsRiding()))
             {
                 //Apply ship rotation
                 if(__instance.m_attached && __instance.m_attachPoint)


### PR DESCRIPTION
When riding a lox with ViewTurnWithMountedAnimal disabled, do not skip the logic in Player_SetMouseLook_Patch() that updates the character's head rotation to face the vr look direction. As a result, the character's head will always be in sync with the vr look direction and the heading of the player marker on the map will indicate the correction direction too.