### PR TITLE
Lock Menu UI's real world position instead of in-game position

### DIFF
--- a/ValheimVRMod/VRCore/UI/VRGUI.cs
+++ b/ValheimVRMod/VRCore/UI/VRGUI.cs
@@ -166,7 +166,7 @@ namespace ValheimVRMod.VRCore.UI
                 if (shouldLockDynamicGuiPosition())
                 {
                     isRecentering = false;
-                    _uiPanel.transform.position = playerInstance.transform.position + _uiPanel.transform.rotation * offsetPosition;
+                    _uiPanel.transform.position = playerInstance.transform.position - getTargetGuiDirection() * 0.2f + _uiPanel.transform.rotation * offsetPosition;
                     return;
                 }
 

--- a/ValheimVRMod/VRCore/UI/VRGUI.cs
+++ b/ValheimVRMod/VRCore/UI/VRGUI.cs
@@ -56,6 +56,9 @@ namespace ValheimVRMod.VRCore.UI
         private float OVERLAY_CURVATURE = 0.25f; /* 0f - 1f */
         private bool USING_OVERLAY = true;
 
+        private bool _wasDynamicGuiPositionLocked;
+        private Vector3 _guiPositionRelatvieToVrCamRig;
+
         private Camera _uiPanelCamera;
         private Camera _guiCamera;
         private Canvas _guiCanvas;
@@ -165,10 +168,21 @@ namespace ValheimVRMod.VRCore.UI
 
                 if (shouldLockDynamicGuiPosition())
                 {
+                    if (!_wasDynamicGuiPositionLocked)
+                    {
+                        // Record the GUI's position relative to the VR rig.
+                        _guiPositionRelatvieToVrCamRig = _uiPanel.transform.position - CameraUtils.getCamera(CameraUtils.VR_CAMERA).transform.parent.position;
+                    }
+                    else
+                    {
+                        // Restore the GUI's position relative to the VR rig.
+                        _uiPanel.transform.position = CameraUtils.getCamera(CameraUtils.VR_CAMERA).transform.parent.position + _guiPositionRelatvieToVrCamRig;
+                    }
+                    _wasDynamicGuiPositionLocked = true;
                     isRecentering = false;
-                    _uiPanel.transform.position = playerInstance.transform.position - getTargetGuiDirection() * 0.2f + _uiPanel.transform.rotation * offsetPosition;
                     return;
                 }
+                _wasDynamicGuiPositionLocked = false;
 
                 var currentDirection = getCurrentGuiDirection();
                 if (isRecentering)
@@ -212,9 +226,7 @@ namespace ValheimVRMod.VRCore.UI
 
         private bool menuIsOpen()
         {
-            bool menuIsOpen = StoreGui.IsVisible() || InventoryGui.IsVisible() || Menu.IsVisible() || (TextViewer.instance && TextViewer.instance.IsVisible()) || Minimap.IsOpen();
-            bool needsRecentering = Player.m_localPlayer.IsRunning() || Player.m_localPlayer.IsAttachedToShip() || Player.m_localPlayer.GetStandingOnShip() != null || Vector3.SqrMagnitude(VRPlayer.instance.transform.position - _uiPanel.transform.position) > 100;
-            return menuIsOpen && !needsRecentering;
+            return StoreGui.IsVisible() || InventoryGui.IsVisible() || Menu.IsVisible() || (TextViewer.instance && TextViewer.instance.IsVisible()) || Minimap.IsOpen();
         }
 
         private bool ensureUIPanel()

--- a/ValheimVRMod/VRCore/UI/VRGUI.cs
+++ b/ValheimVRMod/VRCore/UI/VRGUI.cs
@@ -161,12 +161,15 @@ namespace ValheimVRMod.VRCore.UI
             var offsetPosition = new Vector3(0f, VHVRConfig.GetUiPanelVerticalOffset(), VHVRConfig.GetUiPanelDistance());
             if (useDynamicallyPositionedGui())
             {
+                var playerInstance = Player.m_localPlayer;
+
                 if (shouldLockDynamicGuiPosition())
                 {
                     isRecentering = false;
+                    _uiPanel.transform.position = playerInstance.transform.position + _uiPanel.transform.rotation * offsetPosition;
                     return;
                 }
-                var playerInstance = Player.m_localPlayer;
+
                 var currentDirection = getCurrentGuiDirection();
                 if (isRecentering)
                 {
@@ -189,7 +192,7 @@ namespace ValheimVRMod.VRCore.UI
                     var newRotation = Quaternion.LookRotation(currentDirection, VRPlayer.instance.transform.up);
                     newRotation *= Quaternion.AngleAxis(rotationDelta, Vector3.up);
                     _uiPanel.transform.rotation = newRotation;
-                    _uiPanel.transform.position = playerInstance.transform.position +  newRotation * offsetPosition;
+                    _uiPanel.transform.position = playerInstance.transform.position + newRotation * offsetPosition;
                 }
             }
             else


### PR DESCRIPTION
When locking the UI with an open menu, lock its real world position by moving its in-game position together with the vr camera rig. This way, the UI stays with player when the character is moving - e. g. running, falling, sliding down a hill, riding a lox, sailing, etc.