### PR TITLE
Automatically calculate the amount of arrow rest horizontal offset

### DIFF
--- a/ValheimVRMod/Scripts/BowLocalManager.cs
+++ b/ValheimVRMod/Scripts/BowLocalManager.cs
@@ -312,11 +312,6 @@ namespace ValheimVRMod.Scripts {
             return null;
         }
 
-        private Vector3 getArrowRestPosition() {
-            float arrowRestHorizontalOffset = handleHalfWidth * VHVRConfig.ArrowRestHorizontalOffsetMultiplier();
-            return transform.position - transform.up * VHVRConfig.ArrowRestElevation() + transform.right * arrowRestHorizontalOffset;
-        }
-        
         private Vector3 getAimDir() {
             return (getArrowRestPosition() - pullObj.transform.position).normalized;
         }        

--- a/ValheimVRMod/Scripts/BowLocalManager.cs
+++ b/ValheimVRMod/Scripts/BowLocalManager.cs
@@ -313,7 +313,8 @@ namespace ValheimVRMod.Scripts {
         }
 
         private Vector3 getArrowRestPosition() {
-            return transform.position - transform.up * VHVRConfig.ArrowRestElevation() + transform.right * VHVRConfig.ArrowRestHorizontalOffset();
+            float arrowRestHorizontalOffset = handleHalfWidth * VHVRConfig.ArrowRestHorizontalOffsetMultiplier();
+            return transform.position - transform.up * VHVRConfig.ArrowRestElevation() + transform.right * arrowRestHorizontalOffset;
         }
         
         private Vector3 getAimDir() {

--- a/ValheimVRMod/Scripts/BowManager.cs
+++ b/ValheimVRMod/Scripts/BowManager.cs
@@ -126,7 +126,7 @@ namespace ValheimVRMod.Scripts {
                 }
                 boneWeights[i].weight0 = 1;
             }
-       
+
             // Create the bones for the limbs.
             upperLimbBone = new GameObject("BowUpperLimbBone").transform;
             lowerLimbBone = new GameObject("BowLowerLimbBone").transform;

--- a/ValheimVRMod/Scripts/BowManager.cs
+++ b/ValheimVRMod/Scripts/BowManager.cs
@@ -61,7 +61,7 @@ namespace ValheimVRMod.Scripts {
         }
 
         protected Vector3 getArrowRestPosition() {
-            return transform.TransformPoint(new Vector3(gripLocalHalfWidth * VHVRConfig.ArrowRestHorizontalOffset(), -VHVRConfig.ArrowRestElevation(), 0));
+            return transform.TransformPoint(new Vector3(gripLocalHalfWidth * VHVRConfig.ArrowRestHorizontalOffsetMultiplier(), -VHVRConfig.ArrowRestElevation(), 0));
         }
 
         private void initializeRenderersAsync(Mesh mesh) {
@@ -121,7 +121,7 @@ namespace ValheimVRMod.Scripts {
                     // The vertex is in the lower limb.
                     boneWeights[i].boneIndex0 = 2;
                 }
-                if (0 <= v.y && v.y <= VHVRConfig.ArrowRestElevation()) {
+                if (0 <= v.y && v.y < VHVRConfig.ArrowRestElevation()) {
                     gripLocalHalfWidth = Math.Max(Math.Abs(v.x), gripLocalHalfWidth);
                 }
                 boneWeights[i].weight0 = 1;

--- a/ValheimVRMod/Scripts/BowManager.cs
+++ b/ValheimVRMod/Scripts/BowManager.cs
@@ -25,6 +25,7 @@ namespace ValheimVRMod.Scripts {
         protected bool initialized;
         protected bool wasInitialized;
         protected Outline outline;
+        protected float handleHalfWidth = 0;
 
         public bool pulling;
         public Transform mainHand;
@@ -101,7 +102,7 @@ namespace ValheimVRMod.Scripts {
             for (int i = 0; i < verts.Length; i++) {
                 Vector3 v = verts[i];
                 if (v.y > handleHeight / 2f) {
-                    // The vertex is in the uppler limb.
+                    // The vertex is in the upper limb.
                     boneWeights[i].boneIndex0 = 0;
                 } else if (v.y >= -handleHeight / 2f) {
                     // The vertex is in the handle.
@@ -112,6 +113,7 @@ namespace ValheimVRMod.Scripts {
                     if (v.y < handleBottom.y) {
                         handleBottom = v;
                     }
+                    handleHalfWidth = Math.Max(Math.Abs(v.x), handleHalfWidth);
                 } else {
                     // The vertex is in the lower limb.
                     boneWeights[i].boneIndex0 = 2;

--- a/ValheimVRMod/Scripts/BowManager.cs
+++ b/ValheimVRMod/Scripts/BowManager.cs
@@ -229,7 +229,7 @@ namespace ValheimVRMod.Scripts {
         }
 
         private void rotateBowOnPulling() {
-            float realLifeHandDistance = transform.TransformPoint(mainHand.position).magnitude;
+            float realLifeHandDistance = transform.InverseTransformPoint(mainHand.position).magnitude;
 
             // The angle between the push direction and the arrow direction.
             double pushOffsetAngle = Math.Asin(VHVRConfig.ArrowRestElevation() / realLifeHandDistance);

--- a/ValheimVRMod/Utilities/VHVRConfig.cs
+++ b/ValheimVRMod/Utilities/VHVRConfig.cs
@@ -537,7 +537,7 @@ namespace ValheimVRMod.Utilities
                                                     "Use this to toggle controls of two handed spear (left hand grab while having spear) (experimental)");
             arrowRestElevation = config.Bind("Motion Control",
                 "ArrowRestElevation",
-                0.15f,
+                0.1f,
                 new ConfigDescription("The amount by which the arrow rest is higher than the center of the bow handle",
                     new AcceptableValueRange<float>(0, 0.25f)));
             arrowRestHorizontalOffset = config.Bind("Motion Control",

--- a/ValheimVRMod/Utilities/VHVRConfig.cs
+++ b/ValheimVRMod/Utilities/VHVRConfig.cs
@@ -102,7 +102,7 @@ namespace ValheimVRMod.Utilities
         private static ConfigEntry<bool> spearThrowSpeedDynamic;
         private static ConfigEntry<bool> spearTwoHanded;
         private static ConfigEntry<float> arrowRestElevation;
-        private static ConfigEntry<float> arrowRestHorizontalOffset;
+        private static ConfigEntry<string> arrowRestHorizontalOffset;
         private static ConfigEntry<bool> restrictBowDrawSpeed;
 
 #if DEBUG
@@ -117,6 +117,10 @@ namespace ValheimVRMod.Utilities
 
         // Common values
         private static readonly string[] k_HudAlignmentValues = { "LeftWrist", "RightWrist", "CameraLocked", "Legacy" };
+
+        private const string k_arrowRestCenter = "Center";
+        private const string k_arrowRestAsiatic = "Asiatic";
+        private const string k_arrowRestMediterranean = "Mediterranean";
 
         public static void InitializeConfiguration(ConfigFile mConfig) {
             
@@ -542,9 +546,9 @@ namespace ValheimVRMod.Utilities
                     new AcceptableValueRange<float>(0, 0.25f)));
             arrowRestHorizontalOffset = config.Bind("Motion Control",
                 "ArrowRestHorizontalOffset",
-                0f,
-                new ConfigDescription("The amount by which the arrow rest is to the left and right of the bow center",
-                    new AcceptableValueRange<float>(-0.03f, 0.03f)));
+                k_arrowRestCenter,
+                new ConfigDescription("Which side of the bow should the arrow rest on.",
+                new AcceptableValueList<string>(new string[] { k_arrowRestCenter, k_arrowRestAsiatic, k_arrowRestMediterranean })));
             restrictBowDrawSpeed = config.Bind("Motion Control",
                 "RestrictBowDrawSpeed",
                 false,
@@ -809,9 +813,16 @@ namespace ValheimVRMod.Utilities
             return arrowRestElevation.Value;
         }
 
-        public static float ArrowRestHorizontalOffset()
+        public static float ArrowRestHorizontalOffsetMultiplier()
         {
-            return arrowRestHorizontalOffset.Value;
+            switch (arrowRestHorizontalOffset.Value) {
+                case k_arrowRestAsiatic:
+                    return LeftHanded() ? -1 : 1;
+                case k_arrowRestMediterranean:
+                    return LeftHanded() ? 1 : -1;
+                default:
+                    return 0;
+            }
         }
 
         public static bool RestrictBowDrawSpeed()

--- a/ValheimVRMod/Utilities/VHVRConfig.cs
+++ b/ValheimVRMod/Utilities/VHVRConfig.cs
@@ -102,7 +102,7 @@ namespace ValheimVRMod.Utilities
         private static ConfigEntry<bool> spearThrowSpeedDynamic;
         private static ConfigEntry<bool> spearTwoHanded;
         private static ConfigEntry<float> arrowRestElevation;
-        private static ConfigEntry<string> arrowRestHorizontalOffset;
+        private static ConfigEntry<int> arrowRestHorizontalOffset;
         private static ConfigEntry<bool> restrictBowDrawSpeed;
 
 #if DEBUG
@@ -546,9 +546,9 @@ namespace ValheimVRMod.Utilities
                     new AcceptableValueRange<float>(0, 0.25f)));
             arrowRestHorizontalOffset = config.Bind("Motion Control",
                 "ArrowRestHorizontalOffset",
-                k_arrowRestCenter,
-                new ConfigDescription("Which side of the bow should the arrow rest on.",
-                new AcceptableValueList<string>(new string[] { k_arrowRestCenter, k_arrowRestAsiatic, k_arrowRestMediterranean })));
+                0,
+                new ConfigDescription("Whether the arrow should rest on the left, center, or right of the bow handle",
+                    new AcceptableValueRange<int>(-1, 1)));
             restrictBowDrawSpeed = config.Bind("Motion Control",
                 "RestrictBowDrawSpeed",
                 false,
@@ -813,16 +813,9 @@ namespace ValheimVRMod.Utilities
             return arrowRestElevation.Value;
         }
 
-        public static float ArrowRestHorizontalOffsetMultiplier()
+        public static int ArrowRestHorizontalOffset()
         {
-            switch (arrowRestHorizontalOffset.Value) {
-                case k_arrowRestAsiatic:
-                    return LeftHanded() ? -1 : 1;
-                case k_arrowRestMediterranean:
-                    return LeftHanded() ? 1 : -1;
-                default:
-                    return 0;
-            }
+            return arrowRestHorizontalOffset.Value;
         }
 
         public static bool RestrictBowDrawSpeed()

--- a/ValheimVRMod/Utilities/VHVRConfig.cs
+++ b/ValheimVRMod/Utilities/VHVRConfig.cs
@@ -102,7 +102,7 @@ namespace ValheimVRMod.Utilities
         private static ConfigEntry<bool> spearThrowSpeedDynamic;
         private static ConfigEntry<bool> spearTwoHanded;
         private static ConfigEntry<float> arrowRestElevation;
-        private static ConfigEntry<int> arrowRestHorizontalOffset;
+        private static ConfigEntry<string> arrowRestSide;
         private static ConfigEntry<bool> restrictBowDrawSpeed;
 
 #if DEBUG
@@ -117,6 +117,10 @@ namespace ValheimVRMod.Utilities
 
         // Common values
         private static readonly string[] k_HudAlignmentValues = { "LeftWrist", "RightWrist", "CameraLocked", "Legacy" };
+
+        private const string k_arrowRestCenter = "Center";
+        private const string k_arrowRestAsiatic = "Asiatic";
+        private const string k_arrowRestMediterranean = "Mediterranean";
 
         public static void InitializeConfiguration(ConfigFile mConfig) {
             
@@ -537,14 +541,14 @@ namespace ValheimVRMod.Utilities
                                                     "Use this to toggle controls of two handed spear (left hand grab while having spear) (experimental)");
             arrowRestElevation = config.Bind("Motion Control",
                 "ArrowRestElevation",
-                0.1f,
+                0.15f,
                 new ConfigDescription("The amount by which the arrow rest is higher than the center of the bow handle",
                     new AcceptableValueRange<float>(0, 0.25f)));
-            arrowRestHorizontalOffset = config.Bind("Motion Control",
-                "ArrowRestHorizontalOffset",
-                0,
-                new ConfigDescription("Whether the arrow should rest on the left, center, or right of the bow handle",
-                    new AcceptableValueRange<int>(-1, 1)));
+            arrowRestSide = config.Bind("Motion Control",
+                "ArrowRestSide",
+                k_arrowRestCenter,
+                new ConfigDescription("Whether the arrow should rest on the side of the bow farther from the eyes (Asiatic), the side closer to the eyes (Mediterranean), or the center.",
+                new AcceptableValueList<string>(new string[] { k_arrowRestCenter, k_arrowRestAsiatic, k_arrowRestMediterranean })));
             restrictBowDrawSpeed = config.Bind("Motion Control",
                 "RestrictBowDrawSpeed",
                 false,
@@ -809,9 +813,16 @@ namespace ValheimVRMod.Utilities
             return arrowRestElevation.Value;
         }
 
-        public static int ArrowRestHorizontalOffset()
+        public static float ArrowRestHorizontalOffsetMultiplier()
         {
-            return arrowRestHorizontalOffset.Value;
+            switch (arrowRestSide.Value) {
+                case k_arrowRestAsiatic:
+                    return LeftHanded() ? -1 : 1;
+                case k_arrowRestMediterranean:
+                    return LeftHanded() ? 1 : -1;
+                default:
+                    return 0;
+            }
         }
 
         public static bool RestrictBowDrawSpeed()

--- a/ValheimVRMod/Utilities/VHVRConfig.cs
+++ b/ValheimVRMod/Utilities/VHVRConfig.cs
@@ -118,10 +118,6 @@ namespace ValheimVRMod.Utilities
         // Common values
         private static readonly string[] k_HudAlignmentValues = { "LeftWrist", "RightWrist", "CameraLocked", "Legacy" };
 
-        private const string k_arrowRestCenter = "Center";
-        private const string k_arrowRestAsiatic = "Asiatic";
-        private const string k_arrowRestMediterranean = "Mediterranean";
-
         public static void InitializeConfiguration(ConfigFile mConfig) {
             
             config = mConfig;


### PR DESCRIPTION
Change the slider for arrow rest horizontal offset from continuous to three states. The exact amount of offset is calculated by taking the max of the horizontal offsets of the vertices on the bow grip.

Also revert the vertical elevation of the arrow rest to bow local scale to simplify the code.