### PR TITLE
Allow sliding dominant hand behind non-dominant hand in two-handed wielding mode

### DIFF
--- a/ValheimVRMod/Scripts/WeaponWield.cs
+++ b/ValheimVRMod/Scripts/WeaponWield.cs
@@ -148,17 +148,20 @@ namespace ValheimVRMod.Scripts
                 var distMultiplier = 0f;
                 var originMultiplier = -0.1f;
                 var rotOffset = 180;
+                bool isPoleArmOrSpear = false;
                 switch (attack.m_attackAnimation)
                 {
                     case "spear_poke":
                         distMultiplier = -0.09f;
                         distLimit = 0.09f;
                         originMultiplier = 0.2f;
+                        isPoleArmOrSpear = true;
                         break;
                     case "atgeir_attack":
                         distMultiplier = -0.18f;
                         distLimit = 0.18f;
                         originMultiplier = -0.7f;
+                        isPoleArmOrSpear = true;
                         break;
                 }
                 var CalculateDistance = inversePosition.normalized * distMultiplier / Mathf.Max(handDist, distLimit) - inversePosition.normalized * originMultiplier;
@@ -207,9 +210,9 @@ namespace ValheimVRMod.Scripts
                 {
                     bool mainHandIsDominant = (VHVRConfig.LeftHanded() == (_isTwoHanded == isTwoHanded.MainLeft));
                     transform.position = mainHand.transform.position + CalculateDistance;
-                    if (!mainHandIsDominant) {
+                    if (!mainHandIsDominant && !isPoleArmOrSpear) {
                         // Anchor the weapon on the dominant hand.
-                        transform.position = transform.position - inversePosition;
+                        transform.position = transform.position - inversePosition.normalized * Mathf.Min(handDist, 0.15f);
                     }
                     transform.LookAt(mainHand.transform.position + inversePosition.normalized * 5, transform.up);
                     transform.localRotation = transform.localRotation * (rotSave.transform.localRotation) * Quaternion.AngleAxis(180, Vector3.right) * Quaternion.AngleAxis(rotOffset, transform.InverseTransformDirection(inversePosition));

--- a/ValheimVRMod/Scripts/WeaponWield.cs
+++ b/ValheimVRMod/Scripts/WeaponWield.cs
@@ -205,7 +205,12 @@ namespace ValheimVRMod.Scripts
                 }
                 else
                 {
+                    bool mainHandIsDominant = (VHVRConfig.LeftHanded() == (_isTwoHanded == isTwoHanded.MainLeft));
                     transform.position = mainHand.transform.position + CalculateDistance;
+                    if (!mainHandIsDominant) {
+                        // Anchor the weapon on the dominant hand.
+                        transform.position = transform.position - inversePosition;
+                    }
                     transform.LookAt(mainHand.transform.position + inversePosition.normalized * 5, transform.up);
                     transform.localRotation = transform.localRotation * (rotSave.transform.localRotation) * Quaternion.AngleAxis(180, Vector3.right) * Quaternion.AngleAxis(rotOffset, transform.InverseTransformDirection(inversePosition));
                 }


### PR DESCRIPTION
When the dominant hand is behind the non-dominant hand in two-handed wielding mode, anchor the weapon on the non-dominant hand and allow the dominant hand to slide along the weapon handle. This will increase realism, range of attack of two-handed wielding, and consistence with vanilla game.