### PR TITLE
Rename handedness-related variables to improve readability

### DIFF
--- a/ValheimVRMod/Scripts/BowLocalManager.cs
+++ b/ValheimVRMod/Scripts/BowLocalManager.cs
@@ -175,7 +175,7 @@ namespace ValheimVRMod.Scripts {
                 return;
             }
 
-            (VHVRConfig.LeftHanded() ? VrikCreator.offHandConnector : VrikCreator.mainHandConnector).position = pullObj.transform.position;
+            (VHVRConfig.LeftHanded() ? VrikCreator.leftHandConnector : VrikCreator.rightHandConnector).position = pullObj.transform.position;
             arrowAttach.transform.rotation = pullObj.transform.rotation;
             arrowAttach.transform.position = pullObj.transform.position;
             spawnPoint = getArrowRestPosition();
@@ -197,7 +197,7 @@ namespace ValheimVRMod.Scripts {
                 return;
             }
 
-            (VHVRConfig.LeftHanded() ? VrikCreator.offHandConnector : VrikCreator.mainHandConnector).localPosition = Vector3.zero;
+            (VHVRConfig.LeftHanded() ? VrikCreator.leftHandConnector : VrikCreator.rightHandConnector).localPosition = Vector3.zero;
 
             predictionLine.enabled = false;
             pulling = isPulling = false;

--- a/ValheimVRMod/Scripts/VrikCreator.cs
+++ b/ValheimVRMod/Scripts/VrikCreator.cs
@@ -1,4 +1,4 @@
-﻿using RootMotion.FinalIK;
+using RootMotion.FinalIK;
 using UnityEngine;
 using ValheimVRMod.Utilities;
 
@@ -26,8 +26,8 @@ namespace ValheimVRMod.Scripts {
         private static readonly Quaternion rightSpearRotation = Quaternion.Euler(0, -90, -140);
         private static readonly Vector3 rightSpearEllbow = new Vector3(-1, -3f, 0);
         
-        public static Transform mainHandConnector;
-        public static Transform offHandConnector;
+        public static Transform rightHandConnector;
+        public static Transform leftHandConnector;
 
 
         public static VRIK initialize(GameObject target, Transform leftController, Transform rightController, Transform camera) {
@@ -43,14 +43,14 @@ namespace ValheimVRMod.Scripts {
             vrik.references.rightToes = null;
 
             vrik.solver.leftArm.target = new GameObject().transform;
-            offHandConnector = new GameObject().transform;
-            offHandConnector.SetParent(leftController, false);
-            vrik.solver.leftArm.target.SetParent(offHandConnector, false);
+            leftHandConnector = new GameObject().transform;
+            leftHandConnector.SetParent(leftController, false);
+            vrik.solver.leftArm.target.SetParent(leftHandConnector, false);
             
             vrik.solver.rightArm.target = new GameObject().transform;
-            mainHandConnector = new GameObject().transform;
-            mainHandConnector.SetParent(rightController, false);
-            vrik.solver.rightArm.target.SetParent(mainHandConnector, false);
+            rightHandConnector = new GameObject().transform;
+            rightHandConnector.SetParent(rightController, false);
+            vrik.solver.rightArm.target.SetParent(rightHandConnector, false);
 
             Transform head = new GameObject().transform;
             head.SetParent(camera);

--- a/ValheimVRMod/Scripts/WeaponWield.cs
+++ b/ValheimVRMod/Scripts/WeaponWield.cs
@@ -184,7 +184,7 @@ namespace ValheimVRMod.Scripts
                 rearHandConnector.Rotate(Vector3.right, 10);
 
                 //weapon pos&rotation
-                transform.position = rearHand.tranform.position + weaponOffset;
+                transform.position = rearHand.transform.position + weaponOffset;
                 if (isSpear() && !VHVRConfig.SpearInverseWield())
                 {
                     transform.LookAt(frontHand.transform.position - weaponHoldVector.normalized * 5, transform.up);

--- a/ValheimVRMod/Scripts/WeaponWield.cs
+++ b/ValheimVRMod/Scripts/WeaponWield.cs
@@ -230,7 +230,7 @@ namespace ValheimVRMod.Scripts
 
         private float GetHandAngleDiff(Transform mainHand, Transform refHand)
         {
-            localHandWieldDirection = (attack.m_attackAnimation == "spear_poke") ? new Vector3(0, 0.45f, 0.55f) : Vector3.forward;
+            Vector3 localHandWieldDirection = (attack.m_attackAnimation == "spear_poke") ? new Vector3(0, 0.45f, 0.55f) : Vector3.forward;
             return Vector3.Dot(localHandWieldDirection, mainHand.InverseTransformPoint(refHand.position).normalized);
         }
 

--- a/ValheimVRMod/Scripts/WeaponWield.cs
+++ b/ValheimVRMod/Scripts/WeaponWield.cs
@@ -20,8 +20,8 @@ namespace ValheimVRMod.Scripts
         public enum isTwoHanded
         {
             SingleHanded,
-            MainRight,
-            MainLeft
+            RightHandBehind,
+            LeftHandBehind
         }
 
         private void Awake()
@@ -119,36 +119,33 @@ namespace ValheimVRMod.Scripts
                 SteamVR_Actions.valheim_Grab.GetState(SteamVR_Input_Sources.RightHand) &&
                 !(isSpear() && SpearManager.IsAiming()) )
             {
-                var mainHand = VRPlayer.rightHand;
-                var offHand = VRPlayer.leftHand;
-                float handAngleDiff = Vector3.Dot(GetHandWieldDirection(), VRPlayer.rightHand.transform.InverseTransformPoint(VRPlayer.leftHand.transform.position).normalized);
+                float handAngleDiff = GetHandAngleDiff(VRPlayer.rightHand.transform, VRPlayer.leftHand.transform);
                 if (_isTwoHanded == isTwoHanded.SingleHanded)
                 {
                     if (handAngleDiff > 0.6f)
                     {
-                        _isTwoHanded = isTwoHanded.MainRight;
+                        _isTwoHanded = isTwoHanded.RightHandBehind;
                     }
                     else if (handAngleDiff < -0.6f)
                     {
-                        _isTwoHanded = isTwoHanded.MainLeft;
+                        _isTwoHanded = isTwoHanded.LeftHandBehind;
                     }
                     else
                     {
                         return;
                     }
                 }
-                if (_isTwoHanded == isTwoHanded.MainLeft)
-                {
-                    mainHand = VRPlayer.leftHand;
-                    offHand = VRPlayer.rightHand;
-                }
-                var handDist = Vector3.Distance(mainHand.transform.position, offHand.transform.position);
-                var inversePosition = mainHand.transform.position - offHand.transform.position;
+
+                var rearHand = _isTwoHanded == isTwoHanded.LeftHandBehind ? VRPlayer.leftHand : VRPlayer.rightHand;
+                var frontHand = rearHand.otherHand;
+
+                var handDist = Vector3.Distance(frontHand.transform.position, rearHand.transform.position);
+                var weaponHoldVector = frontHand.transform.position - rearHand.transform.position;
                 var distLimit = 0f;
                 var distMultiplier = 0f;
                 var originMultiplier = -0.1f;
                 var rotOffset = 180;
-                bool rearHandIsDominant = (VHVRConfig.LeftHanded() == (_isTwoHanded == isTwoHanded.MainLeft));
+                bool rearHandIsDominant = (VHVRConfig.LeftHanded() == (_isTwoHanded == isTwoHanded.LeftHandBehind));
                 switch (attack.m_attackAnimation)
                 {
                     case "spear_poke":
@@ -168,53 +165,36 @@ namespace ValheimVRMod.Scripts
                         }
                         break;
                 }
-                var CalculateDistance = inversePosition.normalized * distMultiplier / Mathf.Max(handDist, distLimit) - inversePosition.normalized * originMultiplier;
+                var weaponOffset = weaponHoldVector.normalized * (originMultiplier - distMultiplier / Mathf.Max(handDist, distLimit));
                 ResetOffset();
 
                 //VRIK Hand rotation
-                if (_isTwoHanded == isTwoHanded.MainLeft)
+                var frontHandConnector = _isTwoHanded == isTwoHanded.LeftHandBehind ? VrikCreator.rightHandConnector : VrikCreator.leftHandConnector;
+                var rearHandConnector = _isTwoHanded == isTwoHanded.LeftHandBehind ? VrikCreator.leftHandConnector : VrikCreator.rightHandConnector;
+                frontHandConnector.LookAt(frontHandConnector.position - weaponHoldVector, frontHand.transform.up);
+                rearHandConnector.LookAt(rearHandConnector.position + weaponHoldVector, rearHand.transform.up);
+                if (GetHandAngleDiff(frontHand.transform, rearHand.transform) <= 0)
                 {
-                    VrikCreator.mainHandConnector.LookAt(VrikCreator.offHandConnector, offHand.transform.up);
-                    VrikCreator.offHandConnector.LookAt(VrikCreator.mainHandConnector, mainHand.transform.up);
-                    VrikCreator.mainHandConnector.Rotate(Vector3.up, 180);
-                    if (GetHandAngleDiff(offHand.transform, mainHand.transform) > 0)
-                    {
-                        VrikCreator.mainHandConnector.Rotate(Vector3.up, 180);
-                    }
-                    if (GetHandAngleDiff(mainHand.transform, offHand.transform) < 0)
-                    {
-                        VrikCreator.offHandConnector.Rotate(Vector3.up, 180);
-                    }
+                    frontHandConnector.Rotate(Vector3.up, 180);
                 }
-                else
+                if (GetHandAngleDiff(rearHand.transform, frontHand.transform) < 0)
                 {
-                    VrikCreator.mainHandConnector.LookAt(VrikCreator.offHandConnector, mainHand.transform.up);
-                    VrikCreator.offHandConnector.LookAt(VrikCreator.mainHandConnector, offHand.transform.up);
-                    VrikCreator.offHandConnector.Rotate(Vector3.up, 180);
-                    if (GetHandAngleDiff(offHand.transform, mainHand.transform) > 0)
-                    {
-                        VrikCreator.offHandConnector.Rotate(Vector3.up, 180);
-                    }
-                    if (GetHandAngleDiff(mainHand.transform, offHand.transform) < 0)
-                    {
-                        VrikCreator.mainHandConnector.Rotate(Vector3.up, 180);
-                    }
+                    rearHandConnector.Rotate(Vector3.up, 180);
                 }
-                VrikCreator.mainHandConnector.Rotate(Vector3.right, 10);
+                rearHandConnector.Rotate(Vector3.right, 10);
 
                 //weapon pos&rotation
+                transform.position = rearHand.tranform.position + weaponOffset;
                 if (isSpear() && !VHVRConfig.SpearInverseWield())
                 {
-                    transform.position = mainHand.transform.position + CalculateDistance;
-                    transform.LookAt(offHand.transform.position + inversePosition.normalized * 5, transform.up);
-                    transform.localRotation = transform.localRotation * (rotSave.transform.localRotation) * Quaternion.AngleAxis(180, Vector3.right) * Quaternion.AngleAxis(rotOffset, transform.InverseTransformDirection(inversePosition));
+                    transform.LookAt(frontHand.transform.position - weaponHoldVector.normalized * 5, transform.up);
+                    transform.localRotation = transform.localRotation * (rotSave.transform.localRotation) * Quaternion.AngleAxis(180, Vector3.right) * Quaternion.AngleAxis(rotOffset, transform.InverseTransformDirection(-weaponHoldVector));
                     transform.localRotation = transform.localRotation * (rotSave.transform.localRotation) * Quaternion.AngleAxis(180, Vector3.right);
                 }
                 else
                 {
-                    transform.position = mainHand.transform.position + CalculateDistance;
-                    transform.LookAt(mainHand.transform.position + inversePosition.normalized * 5, transform.up);
-                    transform.localRotation = transform.localRotation * (rotSave.transform.localRotation) * Quaternion.AngleAxis(180, Vector3.right) * Quaternion.AngleAxis(rotOffset, transform.InverseTransformDirection(inversePosition));
+                    transform.LookAt(rearHand.transform.position - weaponHoldVector.normalized * 5, transform.up);
+                    transform.localRotation = transform.localRotation * (rotSave.transform.localRotation) * Quaternion.AngleAxis(180, Vector3.right) * Quaternion.AngleAxis(rotOffset, transform.InverseTransformDirection(-weaponHoldVector));
                 }
 
                 //Atgeir Rotation fix
@@ -242,23 +222,16 @@ namespace ValheimVRMod.Scripts
         }
         private void ResetOffset()
         {
-            VrikCreator.mainHandConnector.localRotation = Quaternion.identity;
-            VrikCreator.offHandConnector.localRotation = Quaternion.identity;
+            VrikCreator.rightHandConnector.localRotation = Quaternion.identity;
+            VrikCreator.leftHandConnector.localRotation = Quaternion.identity;
             transform.position = rotSave.transform.position;
             transform.localRotation = rotSave.transform.localRotation;
-        }
-        private Vector3 GetHandWieldDirection()
-        {
-            if (attack.m_attackAnimation == "spear_poke")
-            {
-                return new Vector3(0, 0.45f, 0.55f);
-            }
-            return new Vector3(0, 0, 1);
         }
 
         private float GetHandAngleDiff(Transform mainHand, Transform refHand)
         {
-            return Vector3.Dot(GetHandWieldDirection(), mainHand.InverseTransformPoint(refHand.position).normalized);
+            localHandWieldDirection = (attack.m_attackAnimation == "spear_poke") ? new Vector3(0, 0.45f, 0.55f) : Vector3.forward;
+            return Vector3.Dot(localHandWieldDirection, mainHand.InverseTransformPoint(refHand.position).normalized);
         }
 
         public static bool isCurrentlyTwoHanded()


### PR DESCRIPTION
Renaming handedness-realted variables to be more descriptive of their usage:

In VrikCreator, rename mainHandConnector to rightHandConnector and offHandConnector to leftHandConnector.

In WeaponWield, rename mainHand to rearHand and offHand to frontHand.