### PR TITLE
Add one-handed aiming mode on bows

### DIFF
--- a/ValheimVRMod/Scripts/BowLocalManager.cs
+++ b/ValheimVRMod/Scripts/BowLocalManager.cs
@@ -86,13 +86,17 @@ namespace ValheimVRMod.Scripts {
 
             base.OnRenderObject();
 
-            var inputSource = VHVRConfig.LeftHanded() ? SteamVR_Input_Sources.LeftHand : SteamVR_Input_Sources.RightHand;
+            var arrowHand = VHVRConfig.LeftHanded() ? SteamVR_Input_Sources.LeftHand : SteamVR_Input_Sources.RightHand;
+            var bowHand = VHVRConfig.LeftHanded() ? SteamVR_Input_Sources.RightHand : SteamVR_Input_Sources.LeftHand;
 
-            if (SteamVR_Actions.valheim_Grab.GetState(inputSource)) {
+            // Enable using the bow hand orientation alone for aiming.
+            oneHandedAiming = SteamVR_Actions.valheim_Grab.GetState(bowHand) && (SteamVR_Actions.valheim_Use.GetState(bowHand) || SteamVR_Actions.valheim_UseLeft.GetState(bowHand));
+
+            if (SteamVR_Actions.valheim_Grab.GetState(arrowHand)) {
                 handlePulling();
             }
 
-            if (SteamVR_Actions.valheim_Grab.GetStateUp(inputSource)) {
+            if (SteamVR_Actions.valheim_Grab.GetStateUp(arrowHand)) {
                 releaseString();
             }
 

--- a/ValheimVRMod/Scripts/BowLocalManager.cs
+++ b/ValheimVRMod/Scripts/BowLocalManager.cs
@@ -89,8 +89,8 @@ namespace ValheimVRMod.Scripts {
             var arrowHand = VHVRConfig.LeftHanded() ? SteamVR_Input_Sources.LeftHand : SteamVR_Input_Sources.RightHand;
             var bowHand = VHVRConfig.LeftHanded() ? SteamVR_Input_Sources.RightHand : SteamVR_Input_Sources.LeftHand;
 
-            // Enable using the bow hand orientation alone for aiming.
-            oneHandedAiming = SteamVR_Actions.valheim_Grab.GetState(bowHand) && (SteamVR_Actions.valheim_Use.GetState(bowHand) || SteamVR_Actions.valheim_UseLeft.GetState(bowHand));
+            // Enable using the bow hand orientation alone for aiming if the bow hand is gripping.
+            oneHandedAiming = SteamVR_Actions.valheim_Grab.GetState(bowHand);
 
             if (SteamVR_Actions.valheim_Grab.GetState(arrowHand)) {
                 handlePulling();

--- a/ValheimVRMod/Scripts/BowLocalManager.cs
+++ b/ValheimVRMod/Scripts/BowLocalManager.cs
@@ -89,8 +89,8 @@ namespace ValheimVRMod.Scripts {
             var arrowHand = VHVRConfig.LeftHanded() ? SteamVR_Input_Sources.LeftHand : SteamVR_Input_Sources.RightHand;
             var bowHand = VHVRConfig.LeftHanded() ? SteamVR_Input_Sources.RightHand : SteamVR_Input_Sources.LeftHand;
 
-            // Enable using the bow hand orientation alone for aiming if the bow hand is gripping.
-            oneHandedAiming = SteamVR_Actions.valheim_Grab.GetState(bowHand);
+            // Enable using the bow hand orientation alone for aiming if the bow hand is holding down both the grip and the trigger.
+            oneHandedAiming = SteamVR_Actions.valheim_Grab.GetState(bowHand) && (SteamVR_Actions.valheim_Use.GetState(bowHand) || SteamVR_Actions.valheim_UseLeft.GetState(bowHand));
 
             if (SteamVR_Actions.valheim_Grab.GetState(arrowHand)) {
                 handlePulling();

--- a/ValheimVRMod/Scripts/BowManager.cs
+++ b/ValheimVRMod/Scripts/BowManager.cs
@@ -231,7 +231,6 @@ namespace ValheimVRMod.Scripts {
 
         private void rotateBowOnPulling() {
             if (oneHandedAiming) {
-                transform.localRotation = originalRotation;
                 return;
             }
 

--- a/ValheimVRMod/Scripts/BowManager.cs
+++ b/ValheimVRMod/Scripts/BowManager.cs
@@ -276,12 +276,7 @@ namespace ValheimVRMod.Scripts {
                 pullPos.x = 0f;
                 pullPos.y = -VHVRConfig.ArrowRestElevation();
             }
-            if (pullPos.z > pullLengthRestriction) {
-                pullPos.z = pullLengthRestriction;
-            }
-            if (pullPos.z < pullStart.z) {
-                pullPos.z = pullStart.z;
-            }
+            pullPos.z = Mathf.Clamp(pullPos.z, pullStart.z, pullLengthRestriction);
 
             pullObj.transform.localPosition = pullPos;
 

--- a/ValheimVRMod/Scripts/BowManager.cs
+++ b/ValheimVRMod/Scripts/BowManager.cs
@@ -266,23 +266,24 @@ namespace ValheimVRMod.Scripts {
         private void pullString() {
 
             Vector3 pullPos = transform.InverseTransformPoint(mainHand.position);
-            if (oneHandedAiming) {
-                pullPos.x = 0f;
-                pullPos.y = -VHVRConfig.ArrowRestElevation();
-            }   
 
             realLifePullPercentage = Mathf.Pow(Math.Min(Math.Max(pullPos.z - pullStart.z, 0) / (maxPullLength - pullStart.z), 1), 2);
 
             // If RestrictBowDrawSpeed is enabled, limit the vr pull length by the square root of the current attack draw percentage to simulate the resistance.
             float pullLengthRestriction = VHVRConfig.RestrictBowDrawSpeed() ? Mathf.Lerp(pullStart.z, maxPullLength, Math.Max(Mathf.Sqrt(Player.m_localPlayer.GetAttackDrawPercentage()), 0.01f)) : maxPullLength;
 
-            if (pullPos.z > pullLengthRestriction) {
-                pullObj.transform.localPosition = new Vector3(pullPos.x, pullPos.y, pullLengthRestriction);
-            } else if (pullPos.z < pullStart.z) {
-                pullObj.transform.localPosition = new Vector3(pullPos.x, pullPos.y, pullStart.z);
-            } else {
-                pullObj.transform.localPosition = pullPos;
+            if (oneHandedAiming) {
+                pullPos.x = 0f;
+                pullPos.y = -VHVRConfig.ArrowRestElevation();
             }
+            if (pullPos.z > pullLengthRestriction) {
+                pullPos.z = pullLengthRestriction;
+            }
+            if (pullPos.z < pullStart.z) {
+                pullPos.z = pullStart.z;
+            }
+
+            pullObj.transform.localPosition = pullPos;
 
             //bHaptics
             if (!BhapticsTactsuit.suitDisabled && realLifePullPercentage != 0)

--- a/ValheimVRMod/Scripts/BowManager.cs
+++ b/ValheimVRMod/Scripts/BowManager.cs
@@ -26,6 +26,7 @@ namespace ValheimVRMod.Scripts {
         protected bool initialized;
         protected bool wasInitialized;
         protected Outline outline;
+        protected bool oneHandedAiming = false;
 
         public bool pulling;
         public Transform mainHand;
@@ -229,6 +230,11 @@ namespace ValheimVRMod.Scripts {
         }
 
         private void rotateBowOnPulling() {
+            if (oneHandedAiming) {
+                transform.localRotation = originalRotation;
+                return;
+            }
+
             float realLifeHandDistance = transform.InverseTransformPoint(mainHand.position).magnitude;
 
             // The angle between the push direction and the arrow direction.
@@ -260,8 +266,12 @@ namespace ValheimVRMod.Scripts {
 
         private void pullString() {
 
-            pullObj.transform.position = mainHand.position;
-            var pullPos = pullObj.transform.localPosition;
+            Vector3 pullPos = transform.InverseTransformPoint(mainHand.position);
+            if (oneHandedAiming) {
+                pullPos.x = 0f;
+                pullPos.y = -VHVRConfig.ArrowRestElevation();
+            }   
+
             realLifePullPercentage = Mathf.Pow(Math.Min(Math.Max(pullPos.z - pullStart.z, 0) / (maxPullLength - pullStart.z), 1), 2);
 
             // If RestrictBowDrawSpeed is enabled, limit the vr pull length by the square root of the current attack draw percentage to simulate the resistance.
@@ -269,10 +279,10 @@ namespace ValheimVRMod.Scripts {
 
             if (pullPos.z > pullLengthRestriction) {
                 pullObj.transform.localPosition = new Vector3(pullPos.x, pullPos.y, pullLengthRestriction);
-            }
-
-            if (pullPos.z < pullStart.z) {
+            } else if (pullPos.z < pullStart.z) {
                 pullObj.transform.localPosition = new Vector3(pullPos.x, pullPos.y, pullStart.z);
+            } else {
+                pullObj.transform.localPosition = pullPos;
             }
 
             //bHaptics


### PR DESCRIPTION
Add one-handed aiming mode which is activated by holding the grips with the bow hand. When activated, the bow hand alone controls the aiming direction and the arrow hand (pulling hand) only affects draw length. One-handed aiming can help remove artificial aiming inaccuracy caused my inaccurate tracking of the arrow hand with inside-out tracking devices (e. g. Quest & Quest 2) when the hand is close to the headset.