### PR TITLE
Fix Bow string bending logic

### DIFF
--- a/ValheimVRMod/Scripts/BowManager.cs
+++ b/ValheimVRMod/Scripts/BowManager.cs
@@ -163,16 +163,32 @@ namespace ValheimVRMod.Scripts {
             }
 
             SkinnedMeshRenderer skinnedMeshRenderer = gameObject.AddComponent<SkinnedMeshRenderer>();
+            MeshRenderer vanillaMeshRenderer = getVanillaBowstringMeshRenderer();
             Mesh mesh = GetComponent<MeshFilter>().mesh;
             mesh.boneWeights = boneWeights;
             mesh.bindposes = bindPoses;
             skinnedMeshRenderer.bones = bones;
             skinnedMeshRenderer.sharedMesh = mesh;
-            skinnedMeshRenderer.material = GetComponent<MeshRenderer>().material;
+            skinnedMeshRenderer.material = vanillaMeshRenderer.material;
             skinnedMeshRenderer.forceMatrixRecalculationPerRender = true;
 
             // Destroy the original renderer since we will be using SkinnedMeshRenderer only.
-            Destroy(GetComponent<MeshRenderer>());
+            Destroy(vanillaMeshRenderer);
+        }
+
+        private MeshRenderer getVanillaBowstringMeshRenderer()
+        {
+            Transform cylinder = transform.Find("Cylinder");
+            if (!cylinder)
+            {
+                LogUtils.LogError("Null Cylinder while getting Bow String MeshRenderer!");
+            }
+            MeshRenderer meshRenderer = cylinder.GetComponent<MeshRenderer>();
+            if (!meshRenderer)
+            {
+                LogUtils.LogError("Null MeshRenderer for Bow String!");
+            }
+            return meshRenderer;
         }
 
         /**

--- a/ValheimVRMod/Scripts/BowManager.cs
+++ b/ValheimVRMod/Scripts/BowManager.cs
@@ -163,7 +163,7 @@ namespace ValheimVRMod.Scripts {
             }
 
             SkinnedMeshRenderer skinnedMeshRenderer = gameObject.AddComponent<SkinnedMeshRenderer>();
-            MeshRenderer vanillaMeshRenderer = getVanillaBowstringMeshRenderer();
+            MeshRenderer vanillaMeshRenderer = getVanillaBowMeshRenderer();
             Mesh mesh = GetComponent<MeshFilter>().mesh;
             mesh.boneWeights = boneWeights;
             mesh.bindposes = bindPoses;
@@ -176,7 +176,7 @@ namespace ValheimVRMod.Scripts {
             Destroy(vanillaMeshRenderer);
         }
 
-        private MeshRenderer getVanillaBowstringMeshRenderer()
+        private MeshRenderer getVanillaBowMeshRenderer()
         {
             Transform cylinder = transform.Find("Cylinder");
             if (!cylinder)


### PR DESCRIPTION
Patch 0.209.8 added a level of hierarchy that causes the MeshRenderer we
replace to be attached to a child object named Cylinder.