### PR TITLE
Fix bow mesh renderer replacement: get vanilla mesh renderer for later use before adding a new mesh renderer

### DIFF
--- a/ValheimVRMod/Scripts/BowManager.cs
+++ b/ValheimVRMod/Scripts/BowManager.cs
@@ -162,17 +162,19 @@ namespace ValheimVRMod.Scripts {
                 bindPoses[i] = bones[i].worldToLocalMatrix * transform.localToWorldMatrix;
             }
 
+            MeshRenderer vanillaMeshRenderer = gameObject.GetComponent<MeshRenderer>();
+            Material bowMaterial = vanillaMeshRenderer.material;
             SkinnedMeshRenderer skinnedMeshRenderer = gameObject.AddComponent<SkinnedMeshRenderer>();
-            Mesh mesh = GetComponent<MeshFilter>().mesh;
+            Mesh mesh = gameObject.GetComponent<MeshFilter>().mesh;
             mesh.boneWeights = boneWeights;
             mesh.bindposes = bindPoses;
             skinnedMeshRenderer.bones = bones;
             skinnedMeshRenderer.sharedMesh = mesh;
-            skinnedMeshRenderer.material = GetComponent<MeshRenderer>().material;
+            skinnedMeshRenderer.material = bowMaterial;
             skinnedMeshRenderer.forceMatrixRecalculationPerRender = true;
 
             // Destroy the original renderer since we will be using SkinnedMeshRenderer only.
-            Destroy(GetComponent<MeshRenderer>());
+            Destroy(vanillaMeshRenderer);
         }
 
         /**


### PR DESCRIPTION
Unity now automatically removes MeshRenderer when a SkinnedMeshRenderer is added to an object. Change the order so that we get the vanilla MeshRenderer before adding the modded SkinnedMeshRenderer to bow.