### PR TITLE
Some Two-handed Enhancement & Fix

### DIFF
--- a/ValheimVRMod/Patches/ControlPatches.cs
+++ b/ValheimVRMod/Patches/ControlPatches.cs
@@ -76,7 +76,7 @@ namespace ValheimVRMod.Patches {
                 var joystick = VRControls.instance.GetJoyLeftStickY();
 
                 //add deadzone to ship control for forward and backward so its harder to accidentally change speed
-                if (Player.m_localPlayer && Player.m_localPlayer.GetControlledShip())
+                if (Player.m_localPlayer?.GetControlledShip())
                 {
                     if(joystick > -0.9f && joystick < 0.9f)
                     {

--- a/ValheimVRMod/Patches/ControlPatches.cs
+++ b/ValheimVRMod/Patches/ControlPatches.cs
@@ -72,7 +72,19 @@ namespace ValheimVRMod.Patches {
     class ZInput_GetJoyLeftStickY_Patch {
         static void Postfix(ref float __result) {
             if (VRControls.mainControlsActive) {
-                __result = __result + VRControls.instance.GetJoyLeftStickY();
+
+                var joystick = VRControls.instance.GetJoyLeftStickY();
+
+                //add deadzone to ship control for forward and backward so its harder to accidentally change speed
+                if (Player.m_localPlayer && Player.m_localPlayer.GetControlledShip())
+                {
+                    if(joystick > -0.9f && joystick < 0.9f)
+                    {
+                        __result = 0f;
+                        return;
+                    }
+                }
+                __result = __result + joystick;
             }
         }
     }
@@ -98,8 +110,8 @@ namespace ValheimVRMod.Patches {
     class ZInput_GetJoyRightStickY_Patch {
 
         private const float NON_TOGGLE_RUN_SENSITIVITY = -0.3f;
-        private const float TOGGLE_RUN_SENSITIVITY = -0.8f;
-        private const float CROUCH_SENSITIVITY = 0.7f;
+        private const float TOGGLE_RUN_SENSITIVITY = -0.85f;
+        private const float CROUCH_SENSITIVITY = 0.85f;
 
         public static bool isCrouching;
         public static bool isRunning;

--- a/ValheimVRMod/Patches/EquipPatches.cs
+++ b/ValheimVRMod/Patches/EquipPatches.cs
@@ -49,6 +49,7 @@ namespace ValheimVRMod.Patches {
                 StaticObjects.quickSwitch.GetComponent<QuickSwitch>().refreshItems();
                 StaticObjects.quickActions.GetComponent<QuickActions>().refreshItems();
             }
+            SpearManager spearManager = null;
 
             switch (EquipScript.getRight()) {
                 case EquipType.Hammer:
@@ -78,14 +79,15 @@ namespace ValheimVRMod.Patches {
 
                         }
                     }
-                    meshFilter.gameObject.AddComponent<SpearManager>();
+                    spearManager = meshFilter.gameObject.AddComponent<SpearManager>();
                     break;
             }
             
             StaticObjects.rightWeaponCollider().GetComponent<WeaponCollision>().setColliderParent(meshFilter.transform, ___m_rightItem, true);
             var weaponWield = ___m_rightItemInstance.AddComponent<WeaponWield>();
             weaponWield.itemName = ___m_rightItem;
-            meshFilter.gameObject.AddComponent<WeaponBlock>().weaponWield = weaponWield; 
+            meshFilter.gameObject.AddComponent<WeaponBlock>().weaponWield = weaponWield;
+            if (spearManager) spearManager.weaponWield = weaponWield;
 
             ParticleFix.maybeFix(___m_rightItemInstance);
         }

--- a/ValheimVRMod/Patches/ShieldPatches.cs
+++ b/ValheimVRMod/Patches/ShieldPatches.cs
@@ -22,7 +22,16 @@ namespace ValheimVRMod.Patches {
             if (__instance != Player.m_localPlayer || !VHVRConfig.UseVrControls()) {
                 return;
             }
-            ___m_blockTimer = ShieldBlock.instance?.blockTimer ?? WeaponBlock.instance?.blockTimer ?? Block.blockTimerNonParry;
+
+            if (WeaponBlock.instance && WeaponBlock.instance.weaponWield.allowBlocking())
+            {
+                ___m_blockTimer = WeaponBlock.instance?.blockTimer ?? Block.blockTimerNonParry;
+            }
+            else
+            {
+                ___m_blockTimer = ShieldBlock.instance?.blockTimer ?? Block.blockTimerNonParry;
+            }
+            
             hit.m_dir = -__instance.transform.forward;
             if (ShieldBlock.instance?.isBlocking() ?? false) { 
                 hand = VRPlayer.leftHand;

--- a/ValheimVRMod/Scripts/Block/WeaponBlock.cs
+++ b/ValheimVRMod/Scripts/Block/WeaponBlock.cs
@@ -20,7 +20,7 @@ namespace ValheimVRMod.Scripts.Block {
 
         public override void setBlocking(Vector3 hitDir) {
             var angle = Vector3.Dot(hitDir, weaponWield.weaponForward);
-            _blocking = weaponWield.allowBlocking() && angle > -0.5f && angle < 0.5f && EquipScript.getLeft() != EquipType.Shield;
+            _blocking = weaponWield.allowBlocking() && angle > -0.5f && angle < 0.5f ;
         }
         
         protected override void ParryCheck(Vector3 posStart, Vector3 posEnd) {

--- a/ValheimVRMod/Scripts/SpearManager.cs
+++ b/ValheimVRMod/Scripts/SpearManager.cs
@@ -13,6 +13,7 @@ namespace ValheimVRMod.Scripts {
         private int tickCounter;
         private List<Vector3> snapshots = new List<Vector3>();
         private GameObject fixedSpear;
+        public WeaponWield weaponWield;
 
         private const float minDist = 0.16f;
         private const float slowThrowModifier = 1.5f;
@@ -123,7 +124,7 @@ namespace ValheimVRMod.Scripts {
                 return;
             }
 
-            if (directionCooldown <= 0) {
+            if (directionCooldown <= 0 || weaponWield.allowBlocking()) {
                 directionCooldown = 0;
                 directionLine.enabled = false;
             }
@@ -235,7 +236,7 @@ namespace ValheimVRMod.Scripts {
         }
         private void UpdateDirectionLine(Vector3 pos1 ,Vector3 pos2)
         {
-            if (!VHVRConfig.UseSpearDirectionGraphic()) {
+            if (!VHVRConfig.UseSpearDirectionGraphic() || weaponWield.allowBlocking()) {
                 return;
             }
             List<Vector3> pointList = new List<Vector3>();

--- a/ValheimVRMod/Scripts/SpearManager.cs
+++ b/ValheimVRMod/Scripts/SpearManager.cs
@@ -87,7 +87,7 @@ namespace ValheimVRMod.Scripts {
                 return;
             }
             
-            if (!SteamVR_Actions.valheim_Grab.GetState(mainHandInputSource)) {
+            if (!SteamVR_Actions.valheim_Grab.GetState(mainHandInputSource) || weaponWield.allowBlocking()) {
                 return;
             }
             

--- a/ValheimVRMod/Scripts/WeaponWield.cs
+++ b/ValheimVRMod/Scripts/WeaponWield.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using ValheimVRMod.Scripts.Block;
 using ValheimVRMod.Utilities;
 using ValheimVRMod.VRCore;
 using Valve.VR;
@@ -19,6 +20,7 @@ namespace ValheimVRMod.Scripts
         private GameObject originalRotSave;
         public static isTwoHanded _isTwoHanded;
         private SteamVR_Input_Sources mainHandInputSource;
+        private float shieldSize = 1f;
 
         public enum isTwoHanded
         {
@@ -91,6 +93,10 @@ namespace ValheimVRMod.Scripts
                     break;
                 default:
                     UpdateTwoHandedWield();
+                    if (!isSpear() && VHVRConfig.TwoHandedWithShield())
+                    {
+                        ShieldBlock.instance?.ScaleShieldSize(shieldSize);
+                    }
                     break;
             }
         }
@@ -229,6 +235,7 @@ namespace ValheimVRMod.Scripts
 
                 weaponForward = transform.forward;
                 weaponSubPos = true;
+                shieldSize = 0.4f;
             }
             else if (SteamVR_Actions.valheim_Grab.GetStateUp(SteamVR_Input_Sources.LeftHand) || 
                      SteamVR_Actions.valheim_Grab.GetStateUp(SteamVR_Input_Sources.RightHand)||
@@ -246,6 +253,7 @@ namespace ValheimVRMod.Scripts
         private void ResetOffset()
         {
             VrikCreator.ResetHandConnectors();
+            shieldSize = 1f;
             transform.position = rotSave.transform.position;
             transform.localRotation = rotSave.transform.localRotation;
         }

--- a/ValheimVRMod/Scripts/WeaponWield.cs
+++ b/ValheimVRMod/Scripts/WeaponWield.cs
@@ -16,6 +16,7 @@ namespace ValheimVRMod.Scripts
         public string itemName;
         private ItemDrop.ItemData item;
         private GameObject rotSave;
+        private GameObject originalRotSave;
         public static isTwoHanded _isTwoHanded;
         private SteamVR_Input_Sources mainHandInputSource;
 
@@ -28,13 +29,25 @@ namespace ValheimVRMod.Scripts
 
         private void Awake()
         {
+            item = Player.m_localPlayer.GetRightItem();
+            attack = item.m_shared.m_attack.Clone();
+
             rotSave = new GameObject();
             rotSave.transform.SetParent(transform.parent);
             rotSave.transform.position = transform.position;
+            //atgeir wield rotation fix
+            originalRotSave = new GameObject();
+            originalRotSave.transform.SetParent(transform.parent);
+            originalRotSave.transform.position = transform.position;
+            originalRotSave.transform.localRotation = transform.localRotation;
+            switch (attack.m_attackAnimation)
+            {
+                case "atgeir_attack":
+                    transform.localRotation = transform.localRotation * Quaternion.AngleAxis(-20 , Vector3.up) * Quaternion.AngleAxis(-7 , Vector3.right);
+                    break;
+            }
             rotSave.transform.localRotation = transform.localRotation;
 
-            item = Player.m_localPlayer.GetRightItem();
-            attack = item.m_shared.m_attack.Clone();
             _isTwoHanded = isTwoHanded.SingleHanded;
 
             if (VHVRConfig.LeftHanded())
@@ -200,19 +213,20 @@ namespace ValheimVRMod.Scripts
                     transform.localRotation = transform.localRotation * (rotSave.transform.localRotation) * Quaternion.AngleAxis(180, Vector3.right) * Quaternion.AngleAxis(rotOffset, transform.InverseTransformDirection(-weaponHoldVector));
                     transform.localRotation = transform.localRotation * (rotSave.transform.localRotation) * Quaternion.AngleAxis(180, Vector3.right);
                 }
+                else if(attack.m_attackAnimation == "atgeir_attack")
+                {
+                    transform.LookAt(rearHandCenter - weaponHoldVector.normalized * 5, transform.up);
+                    transform.localRotation = transform.localRotation * (originalRotSave.transform.localRotation) * Quaternion.AngleAxis(180, Vector3.right) * Quaternion.AngleAxis(rotOffset, transform.InverseTransformDirection(-weaponHoldVector));
+                    //var debugRot = VHVRConfig.getDebugRot();
+                    //LogUtils.LogDebug("x: " + debugRot.x + " y: " + debugRot.y + " z: " + debugRot.z);
+                    transform.localRotation = transform.localRotation * Quaternion.AngleAxis(-19.1f, Vector3.up) * Quaternion.AngleAxis(-8, Vector3.right);
+                }
                 else
                 {
                     transform.LookAt(rearHandCenter - weaponHoldVector.normalized * 5, transform.up);
                     transform.localRotation = transform.localRotation * (rotSave.transform.localRotation) * Quaternion.AngleAxis(180, Vector3.right) * Quaternion.AngleAxis(rotOffset, transform.InverseTransformDirection(-weaponHoldVector));
                 }
 
-                //Atgeir Rotation fix
-                switch (attack.m_attackAnimation)
-                {
-                    case "atgeir_attack":
-                        transform.localRotation = transform.localRotation * Quaternion.AngleAxis(-20, Vector3.up) * Quaternion.AngleAxis(-7, Vector3.right);
-                        break;
-                }
                 weaponForward = transform.forward;
                 weaponSubPos = true;
             }


### PR DESCRIPTION
- Change how blocking works when allowing two-handed while having shield, uses two handed logic instead of shield
- remove direction line from spear while two-handed
- probably fix atgeir holding angle
- resize shield (to 0.4x) while twohanded shield is turned on
- disable throwing while two handed wield spear (allowing you to loot while using two handed spear)

additional changes 
- change running and crouching deadzone to 0.85f
- add deadzone to ship controls (move forward and backward) to 0.9 