### PR TITLE
Destroy outline of attack targets after cooldown

### DIFF
--- a/ValheimVRMod/Scripts/AttackTargetMeshCooldown.cs
+++ b/ValheimVRMod/Scripts/AttackTargetMeshCooldown.cs
@@ -38,6 +38,11 @@ namespace ValheimVRMod.Scripts {
         {
             return lastAttackTargetMeshCooldown != null && lastAttackTargetMeshCooldown.inCoolDown();
         }
+        
+        protected override bool keepOutlineInstance()
+        {
+            return false;
+        }
 
         protected override void OnDisable() {
             lastAttackTargetMeshCooldown = null;

--- a/ValheimVRMod/Scripts/AttackTargetMeshCooldown.cs
+++ b/ValheimVRMod/Scripts/AttackTargetMeshCooldown.cs
@@ -7,11 +7,6 @@ namespace ValheimVRMod.Scripts {
         public static bool staminaDrained;
         private static MeshCooldown lastAttackTargetMeshCooldown;
 
-        void Awake()
-        {
-            keepOutlineInstance = false;
-        }
-
         public override bool tryTrigger(float cd) {
             bool isTriggered = base.tryTrigger(cd);
             if (isTriggered && lastAttackTargetMeshCooldown == null) {

--- a/ValheimVRMod/Scripts/AttackTargetMeshCooldown.cs
+++ b/ValheimVRMod/Scripts/AttackTargetMeshCooldown.cs
@@ -7,6 +7,11 @@ namespace ValheimVRMod.Scripts {
         public static bool staminaDrained;
         private static MeshCooldown lastAttackTargetMeshCooldown;
 
+        void Awake()
+        {
+            keepOutlineInstance = false;
+        }
+
         public override bool tryTrigger(float cd) {
             bool isTriggered = base.tryTrigger(cd);
             if (isTriggered) {

--- a/ValheimVRMod/Scripts/MeshCooldown.cs
+++ b/ValheimVRMod/Scripts/MeshCooldown.cs
@@ -3,7 +3,6 @@ using ValheimVRMod.Utilities;
 
 namespace ValheimVRMod.Scripts {
     public class MeshCooldown : MonoBehaviour {
-        public bool keepOutlineInstance = true;
 
         private static readonly Color FullOutlineColor = Color.red;
         private static readonly Color HiddenOutlineColor = new Color(1, 0, 0, 0);
@@ -26,6 +25,12 @@ namespace ValheimVRMod.Scripts {
             if (outline == null) {
                 outline = gameObject.AddComponent<Outline>();
             }
+        }
+
+        // Whether the outline should be kept (as opposed to destroyed) after cooldown finishes.
+        protected virtual bool keepOutlineInstance()
+        {
+            return true;
         }
 
         protected virtual void OnDisable() {
@@ -68,7 +73,7 @@ namespace ValheimVRMod.Scripts {
            
             if (! inCoolDown()) {
                 outline.OutlineMode = Outline.Mode.OutlineHidden;
-                if (!keepOutlineInstance) {
+                if (!keepOutlineInstance()) {
                     Destroy(outline);
                     outline = null;
                 }


### PR DESCRIPTION
After the mesh cooldown on an attack target, destroy (rather than just hiding) the outline.
This should not affect block mesh cool downs.

When an outline is hidden, the mesh it is on can still occlude other objects outlines even if those objects are closer the player.