### PR TITLE
Cleanup: further simplify quick menu handedness logic and improve naming consistency

### DIFF
--- a/ValheimVRMod/Scripts/QuickAbstract.cs
+++ b/ValheimVRMod/Scripts/QuickAbstract.cs
@@ -35,7 +35,7 @@ namespace ValheimVRMod.Scripts
 
         protected GameObject sphere;
 
-        public Transform parent;
+        protected abstract Transform handTransform { get; }
         private Transform quickMenuLocker;
         protected GameObject wrist;
         protected GameObject radialMenu;
@@ -135,7 +135,7 @@ namespace ValheimVRMod.Scripts
 
         private void OnEnable()
         {
-            transform.SetParent(parent, false);
+            transform.SetParent(handTransform, false);
             transform.localPosition = Vector3.zero;
 
             switch (VHVRConfig.getQuickMenuType())
@@ -203,7 +203,7 @@ namespace ValheimVRMod.Scripts
 
             if (sphere)
             {
-                sphere.transform.position = parent.position;
+                sphere.transform.position = handTransform.position;
             }
             hoverItem();
         }
@@ -327,14 +327,14 @@ namespace ValheimVRMod.Scripts
             Quaternion hoverRot = Quaternion.identity;
             hoveredIndex = -1;
 
-            var projectedPos = Vector3.Project(parent.position - transform.position, transform.forward);
+            var projectedPos = Vector3.Project(handTransform.position - transform.position, transform.forward);
             transform.position += projectedPos;
             sphere.transform.position -= projectedPos;
 
             //extraItems
             for (int i = 0; i < extraElementCount; i++)
             {
-                var dist = Vector3.Distance(parent.position, extraElements[i].transform.position);
+                var dist = Vector3.Distance(handTransform.position, extraElements[i].transform.position);
 
                 if (dist < maxDist)
                 {
@@ -357,11 +357,11 @@ namespace ValheimVRMod.Scripts
             else if (hoveredIndex == -1 && elementCount != 0)
             {
                 radialMenu.gameObject.SetActive(true);
-                var convertedPos = transform.InverseTransformPoint(parent.position);
+                var convertedPos = transform.InverseTransformPoint(handTransform.position);
                 convertedPos = new Vector3(convertedPos.x, convertedPos.y, 0);
                 //var currentangle = Vector3.SignedAngle(transform.up, parent.position - transform.position, -transform.forward);
                 var currentangle = Vector3.SignedAngle(Vector3.up, convertedPos.normalized, -Vector3.forward);
-                var distFromCenter = Vector3.Distance(transform.position, parent.position);
+                var distFromCenter = Vector3.Distance(transform.position, handTransform.position);
                 if (distFromCenter > 0.07f)
                 {
                     var elementAngle = 360 / elementCount;
@@ -430,7 +430,7 @@ namespace ValheimVRMod.Scripts
 
         protected bool IsInArea()
         {
-            var wristBasedPos = wrist.transform.InverseTransformPoint(parent.position);
+            var wristBasedPos = wrist.transform.InverseTransformPoint(handTransform.position);
             if (wristBasedPos.y > -0.07f && wristBasedPos.y < 0.07f &&
                 wristBasedPos.z > -0.07f && wristBasedPos.z < 0.07f &&
                 wristBasedPos.x > -0.15f && wristBasedPos.x < 0.15f)
@@ -452,13 +452,6 @@ namespace ValheimVRMod.Scripts
 
         protected void refreshRadialItems(bool isDominantHand)
         {
-            Transform handTransform = isDominantHand ? VRPlayer.dominantHand.transform : VRPlayer.dominantHand.otherHand.transform;
-            if (parent != handTransform )
-            {
-                parent = handTransform;
-                transform.position = handTransform.position;
-            }
-
             if (Player.m_localPlayer == null)
             {
                 return;
@@ -486,7 +479,7 @@ namespace ValheimVRMod.Scripts
             }
         }
 
-        protected void RefreshQuickAction()
+        protected void RefreshWristQuickAction()
         {
             extraElementCount = 0;
             Inventory inventory = Player.m_localPlayer.GetInventory();
@@ -508,7 +501,7 @@ namespace ValheimVRMod.Scripts
             }
         }
 
-        protected void RefreshQuickSwitch()
+        protected void RefreshWristQuickSwitch()
         {
             StatusEffect se;
             float cooldown;

--- a/ValheimVRMod/Scripts/QuickActions.cs
+++ b/ValheimVRMod/Scripts/QuickActions.cs
@@ -18,7 +18,7 @@ namespace ValheimVRMod.Scripts {
 
         protected override void ExecuteHapticFeedbackOnHoverTo()
         {
-            VRPlayer.leftHand.otherHand.hapticAction.Execute(0, 0.1f, 40, 0.1f, SteamVR_Input_Sources.LeftHand);
+            VRPlayer.leftHand.hapticAction.Execute(0, 0.1f, 40, 0.1f, SteamVR_Input_Sources.LeftHand);
         }
 
         protected override Transform handTransform { get { return VRPlayer.leftHand.transform; } }

--- a/ValheimVRMod/Scripts/QuickActions.cs
+++ b/ValheimVRMod/Scripts/QuickActions.cs
@@ -5,6 +5,7 @@ using ValheimVRMod.VRCore;
 using Valve.VR;
 
 namespace ValheimVRMod.Scripts {
+    // TODO: rename this to LeftHandQuickMenu. This class is not specific to quick switches.
     public class QuickActions : QuickAbstract {
 
         public static QuickActions instance;
@@ -17,30 +18,33 @@ namespace ValheimVRMod.Scripts {
 
         protected override void ExecuteHapticFeedbackOnHoverTo()
         {
-            VRPlayer.dominantHand.otherHand.hapticAction.Execute(0, 0.1f, 40, 0.1f, VRPlayer.nonDominantHandInputSource);
+            VRPlayer.leftHand.otherHand.hapticAction.Execute(0, 0.1f, 40, 0.1f, SteamVR_Input_Sources.LeftHand);
         }
+
+        protected override Transform handTransform { get { return VRPlayer.leftHand.transform; } }
 
         public override void UpdateWristBar()
         {
-            if(wrist.transform.parent != VRPlayer.dominantHand.transform)
+            // The wrist bar is on the other hand.
+            if (wrist.transform.parent != VRPlayer.rightHand.transform)
             {
-                wrist.transform.SetParent(VRPlayer.dominantHand.transform);
+                wrist.transform.SetParent(VRPlayer.rightHand.transform);
             }
-            wrist.transform.localPosition = VHVRConfig.DominantHandWristQuickBarPos();
-            wrist.transform.localRotation = VHVRConfig.DominantHandWristQuickBarRot();
+            wrist.transform.localPosition = VHVRConfig.RightWristQuickBarPos();
+            wrist.transform.localRotation = VHVRConfig.RightWristQuickBarRot();
             wrist.SetActive(isInView() || IsInArea());
         }
 
         public override void refreshItems() {
-            refreshRadialItems(/* isDominantHand= */ false);
+            refreshRadialItems(/* isDominantHand= */ VHVRConfig.LeftHanded());
 
-            if (VHVRConfig.QuickActionOnLeftHand() ^ VHVRConfig.LeftHanded())
+            if (VHVRConfig.QuickActionOnLeftHand())
             {
-                RefreshQuickAction();
+                RefreshWristQuickAction();
             }
             else
             {
-                RefreshQuickSwitch();
+                RefreshWristQuickSwitch();
             }
                 
             reorderElements();

--- a/ValheimVRMod/Scripts/QuickSwitch.cs
+++ b/ValheimVRMod/Scripts/QuickSwitch.cs
@@ -5,6 +5,7 @@ using ValheimVRMod.VRCore;
 using Valve.VR;
 
 namespace ValheimVRMod.Scripts {
+    // TODO: rename this to RightHandQuickMenu. This class is not specific to quick switches.
     public class QuickSwitch : QuickAbstract {
 
         public static QuickSwitch instance;
@@ -17,33 +18,37 @@ namespace ValheimVRMod.Scripts {
 
         protected override void ExecuteHapticFeedbackOnHoverTo()
         {
-            VRPlayer.dominantHand.hapticAction.Execute(0, 0.1f, 40, 0.1f, VRPlayer.dominantHandInputSource);
+            VRPlayer.rightHand.hapticAction.Execute(0, 0.1f, 40, 0.1f, SteamVR_Input_Sources.RightHand);
         }
+
+        protected override Transform handTransform { get { return VRPlayer.rightHand.transform; } }
 
         public override void UpdateWristBar()
         {
-            if (wrist.transform.parent != VRPlayer.dominantHand.otherHand.transform)
+            // The wrist bar is on the other hand.
+            if (wrist.transform.parent != VRPlayer.leftHand.transform)
             {
-                wrist.transform.SetParent(VRPlayer.dominantHand.otherHand.transform);
+                wrist.transform.SetParent(VRPlayer.leftHand.transform);
             }
-            wrist.transform.localPosition = VHVRConfig.NonDominantHandWristQuickBarPos();
-            wrist.transform.localRotation = VHVRConfig.NonDominantHandWristQuickBarRot();
+            wrist.transform.localPosition = VHVRConfig.LeftWristQuickBarPos();
+            wrist.transform.localRotation = VHVRConfig.LeftWristQuickBarRot();
             wrist.SetActive(isInView() || IsInArea());
         }
+
         /**
          * loop the inventory hotbar and set corresponding item icons + activate equipped layers
          */
         public override void refreshItems() {
-            refreshRadialItems(/* isDominantHand= */ true);
+            refreshRadialItems(/* isDominantHand= */ !VHVRConfig.LeftHanded());
 
             //Extra
-            if (VHVRConfig.QuickActionOnLeftHand() ^ VHVRConfig.LeftHanded())
+            if (VHVRConfig.QuickActionOnLeftHand())
             {
-                RefreshQuickSwitch();
+                RefreshWristQuickSwitch();
             }
             else
             {
-                RefreshQuickAction();
+                RefreshWristQuickAction();
             }
 
             reorderElements();

--- a/ValheimVRMod/Utilities/StaticObjects.cs
+++ b/ValheimVRMod/Utilities/StaticObjects.cs
@@ -65,15 +65,15 @@ namespace ValheimVRMod.Utilities {
             return collisionScript = collisionObj.AddComponent<T>();
         } 
         
-        public static void addQuickActions(Transform hand) {
+        public static void addQuickActions() {
             quickActions = new GameObject();
-            quickActions.AddComponent<QuickActions>().parent = hand;
+            quickActions.AddComponent<QuickActions>();
             quickActions.SetActive(false);
         }
         
-        public static void addQuickSwitch(Transform hand) {
+        public static void addQuickSwitch() {
             quickSwitch = new GameObject();
-            quickSwitch.AddComponent<QuickSwitch>().parent = hand;
+            quickSwitch.AddComponent<QuickSwitch>();
             quickSwitch.SetActive(false);
         }
 

--- a/ValheimVRMod/VRCore/UI/VRControls.cs
+++ b/ValheimVRMod/VRCore/UI/VRControls.cs
@@ -108,10 +108,8 @@ namespace ValheimVRMod.VRCore.UI
                 }
             }
 
-            checkQuickItems<QuickSwitch>(StaticObjects.quickSwitch, 
-                VHVRConfig.LeftHanded() ?  SteamVR_Actions.valheim_QuickActions : SteamVR_Actions.valheim_QuickSwitch, true);
-            checkQuickItems<QuickActions>(StaticObjects.quickActions,  
-                VHVRConfig.LeftHanded() ?  SteamVR_Actions.valheim_QuickSwitch : SteamVR_Actions.valheim_QuickActions, false);
+            checkQuickItems<QuickSwitch>(StaticObjects.quickSwitch, SteamVR_Actions.valheim_QuickSwitch, true);
+            checkQuickItems<QuickActions>(StaticObjects.quickActions, SteamVR_Actions.valheim_QuickActions, false);
         }
 
         void FixedUpdate()

--- a/ValheimVRMod/VRCore/VRPlayer.cs
+++ b/ValheimVRMod/VRCore/VRPlayer.cs
@@ -826,8 +826,8 @@ namespace ValheimVRMod.VRCore
             StaticObjects.rightFist().setColliderParent(_vrik.references.rightHand, true);
             Player.m_localPlayer.gameObject.AddComponent<FistBlock>();
             StaticObjects.mouthCollider(cam.transform);
-            StaticObjects.addQuickActions(dominantHand.otherHand.transform);
-            StaticObjects.addQuickSwitch(dominantHand.transform);
+            StaticObjects.addQuickActions();
+            StaticObjects.addQuickSwitch();
             QuickActions.instance.refreshItems();
             QuickSwitch.instance.refreshItems();
         }


### PR DESCRIPTION
The impl of QuickAction and QuickSwitch is not really specific to quick actions or quick switches. Instead, their different is only on which hand they are for. Furthermore, we have inconsistent usage of "QuickAction" and "QuickSwitch" in VRControls:
https://github.com/brandonmousseau/vhvr-mod/blob/79b1b2074871eb20f2cbb4c57753a402cc11c6f5/ValheimVRMod/VRCore/UI/VRControls.cs#L111

Overall, it will improve code health if we explicity dedicate one of them to the left hand and the other to the right hand.