### PR TITLE
Repurpose ThrowableWeaponWield as SpearWield

### DIFF
--- a/ValheimVRMod/Patches/EquipPatches.cs
+++ b/ValheimVRMod/Patches/EquipPatches.cs
@@ -65,16 +65,16 @@ namespace ValheimVRMod.Patches {
                     meshFilter.gameObject.AddComponent<FishingManager>();
                     break;
             }
-            WeaponWield weaponWield;
+            WeaponWield weaponWield = EquipScript.isSpearEquipped() ? ___m_rightItemInstance.AddComponent<SpearWield>() : ___m_rightItemInstance.AddComponent<WeaponWield>();
+            weaponWield.itemName = ___m_rightItem;
+            weaponWield.Initialize(false);
+
             if (EquipScript.isThrowable(player.GetRightItem()) || EquipScript.isSpearEquipped() || EquipScript.getRight() == EquipType.ThrowObject)
             {
-                weaponWield = ___m_rightItemInstance.AddComponent<ThrowableWeaponWield>().Initialize(false);
+                // TODO: rename this to ThrowableManager
+                (meshFilter.gameObject.AddComponent<SpearManager>()).weaponWield = weaponWield;
             }
-            else
-            {
-                weaponWield = ___m_rightItemInstance.AddComponent<WeaponWield>().Initialize(false);
-            }
-            weaponWield.itemName = ___m_rightItem;
+
             var weaponCol = StaticObjects.rightWeaponCollider().GetComponent<WeaponCollision>();
             weaponCol.setColliderParent(meshFilter.transform, ___m_rightItem, true);
             weaponCol.weaponWield = weaponWield;

--- a/ValheimVRMod/Scripts/SpearWield.cs
+++ b/ValheimVRMod/Scripts/SpearWield.cs
@@ -5,9 +5,8 @@ using Valve.VR;
 
 namespace ValheimVRMod.Scripts
 {
-    class ThrowableWeaponWield : WeaponWield
+    class SpearWield : WeaponWield
     {
-        private SpearManager spearManager;
         void Awake()
         {
             MeshFilter meshFilter = gameObject.GetComponentInChildren<MeshFilter>();
@@ -26,10 +25,6 @@ namespace ValheimVRMod.Scripts
                         break;
                 }
             }
-
-            // TODO: consider renaming this ThrowableManager
-            spearManager = meshFilter.gameObject.AddComponent<SpearManager>();
-            spearManager.weaponWield = this;
         }
 
         protected override Quaternion GetSingleHandedRotation(Quaternion originalRotation)
@@ -41,7 +36,7 @@ namespace ValheimVRMod.Scripts
 
         protected override bool TemporaryDisableTwoHandedWield()
         {
-            return EquipScript.isSpearEquipped() && (SpearManager.IsAiming() || SpearManager.isThrowing);
+            return SpearManager.IsAiming() || SpearManager.isThrowing;
         }
 
         protected override Vector3 GetSingleHandedWeaponPointingDir()


### PR DESCRIPTION
The only logic in ThrowableWeaponWield differing from its base class are spear-specific, so it shall be used only for spears.