### PR TITLE
Implement roomscale secondary attack

### DIFF
--- a/ValheimVRMod/Scripts/WeaponCollision.cs
+++ b/ValheimVRMod/Scripts/WeaponCollision.cs
@@ -27,11 +27,12 @@ namespace ValheimVRMod.Scripts {
         private Outline outline;
         private float hitTime;
         private bool hasDrunk;
+        private float postSecondaryAttackCountdown;
 
         public PhysicsEstimator physicsEstimator { get; private set; }
         public PhysicsEstimator mainHandPhysicsEstimator { get { return weaponWield.mainHand == VRPlayer.leftHand ? VRPlayer.leftHandPhysicsEstimator : VRPlayer.rightHandPhysicsEstimator; } }
         public bool lastAttackWasStab { get; private set; }
-        public bool atgeirSecondaryAttackInProgress { get; private set; }
+        public float twoHandedMultitargetSwipeCountdown { get; private set; } = 0;
         public bool itemIsTool;
         public static bool isDrinking;
         public WeaponWield weaponWield;
@@ -107,22 +108,34 @@ namespace ValheimVRMod.Scripts {
                 return;
             }
 
-            if (!tryHitTarget(collider.gameObject)) {
+            bool isSecondaryAttack = postSecondaryAttackCountdown <= 0 && RoomscaleSecondaryAttackUtils.IsSecondaryAttack(this);
+            if (EquipScript.getRight() == EquipType.Polearms)
+            {
+                // Allow continuing an ongoing atgeir secondary attack (multitarget swipe) until cooldown finishes.
+                isSecondaryAttack = postSecondaryAttackCountdown > 0 || isSecondaryAttack;
+            }
+
+            if (!tryHitTarget(collider.gameObject, isSecondaryAttack)) {
                 return;
             }
+
+            if (isSecondaryAttack && postSecondaryAttackCountdown <= 0)
+            {
+                postSecondaryAttackCountdown = WeaponUtils.GetAttackDuration(secondaryAttack);
+            }
+
+            Attack currentAttack = isSecondaryAttack ? secondaryAttack : attack;
+
+            if (WeaponUtils.IsTwoHandedMultitargetSwipe(currentAttack) && twoHandedMultitargetSwipeCountdown <= 0)
+            {
+                twoHandedMultitargetSwipeCountdown = WeaponUtils.GetAttackDuration(currentAttack);
+            }     
 
             StaticObjects.lastHitPoint = transform.position;
             StaticObjects.lastHitDir = physicsEstimator.GetVelocity().normalized;
             StaticObjects.lastHitCollider = collider;
 
-            bool isSecondaryAttack = RoomscaleSecondaryAttackUtils.IsSecondaryAttack(this);
-            if (EquipScript.getRight() == EquipType.Polearms)
-            {
-                // Allow continuing an ongoing Atgeir secondary attack until cooldown finishes.
-                isSecondaryAttack = atgeirSecondaryAttackInProgress = (atgeirSecondaryAttackInProgress || isSecondaryAttack);
-            }
-
-            if ((isSecondaryAttack ? secondaryAttack : attack).Start(Player.m_localPlayer, null, null,
+            if (currentAttack.Start(Player.m_localPlayer, null, null,
                         Player.m_localPlayer.m_animEvent,
                         null, item, null, 0.0f, 0.0f))
             {
@@ -140,7 +153,7 @@ namespace ValheimVRMod.Scripts {
             }
         }
 
-        private bool tryHitTarget(GameObject target) {
+        private bool tryHitTarget(GameObject target, bool isSecondaryAttack) {
 
             // ignore certain Layers
             if (ignoreLayers.Contains(target.layer)) {
@@ -176,7 +189,15 @@ namespace ValheimVRMod.Scripts {
                 attackTargetMeshCooldown = target.AddComponent<AttackTargetMeshCooldown>();
             }
 
-            return attackTargetMeshCooldown.tryTrigger(hitTime);
+            if (isSecondaryAttack)
+            {
+                // Use the target cooldown time of the primary attack if it is shorter to allow primary attack immediately after secondary attack;
+                // The secondary attack cooldown time is manage by postSecondaryAttackCountdown in this class intead.
+                float targetCooldownTime = Mathf.Min(WeaponUtils.GetAttackDuration(attack), WeaponUtils.GetAttackDuration(secondaryAttack));
+                return attackTargetMeshCooldown.tryTrigger(targetCooldownTime);
+            }
+            
+            return attackTargetMeshCooldown.tryTrigger(WeaponUtils.GetAttackDuration(attack));
         }
 
         private void OnRenderObject() {
@@ -207,6 +228,7 @@ namespace ValheimVRMod.Scripts {
             attack = item.m_shared.m_attack.Clone();
             secondaryAttack = item.m_shared.m_secondaryAttack.Clone();
 
+            // Cleanup unused hitTime
             switch (attack.m_attackAnimation) {
                 case "atgeir_attack":
                     hitTime = 0.81f;
@@ -264,19 +286,29 @@ namespace ValheimVRMod.Scripts {
                 return;
             }
 
-            var inCooldown = AttackTargetMeshCooldown.isPrimaryTargetInCooldown();
-            if (!inCooldown)
+            bool inCooldown = AttackTargetMeshCooldown.isPrimaryTargetInCooldown();
+            bool canDoPrimaryAttack =
+                Player.m_localPlayer.HaveStamina(getStaminaUsage() + 0.1f) && (attack.m_attackType == Attack.AttackType.Horizontal || !inCooldown);
+            if (!canDoPrimaryAttack)
             {
-                atgeirSecondaryAttackInProgress = false;
+                if (!outline.enabled)
+                {
+                    outline.enabled = true;
+                }
+                outline.OutlineColor = Color.red;
+                outline.OutlineWidth = 5;
             }
-
-            if (outline.enabled && Player.m_localPlayer.HaveStamina(getStaminaUsage() + 0.1f)
-                                && (attack.m_attackType == Attack.AttackType.Horizontal || !inCooldown)) {
+            else if (postSecondaryAttackCountdown > 0.5f) {
+                if (!outline.enabled)
+                {
+                    outline.enabled = true;
+                }
+                outline.OutlineColor = Color.Lerp(new Color(1, 1, 0, 0), Color.yellow, postSecondaryAttackCountdown - 0.5f);
+                outline.OutlineWidth = 10;
+            }
+            else if (outline.enabled)
+            {
                 outline.enabled = false;
-            }
-            else if (!outline.enabled && (!Player.m_localPlayer.HaveStamina(getStaminaUsage() + 0.1f)
-                                          || attack.m_attackType != Attack.AttackType.Horizontal && inCooldown)) {
-                outline.enabled = true;
             }
         }
 
@@ -303,6 +335,15 @@ namespace ValheimVRMod.Scripts {
         }
         
         private void FixedUpdate() {
+            if (postSecondaryAttackCountdown > 0)
+            {
+                postSecondaryAttackCountdown -= Time.fixedDeltaTime;
+            }
+            if (twoHandedMultitargetSwipeCountdown > 0)
+            {
+                postSecondaryAttackCountdown -= Time.fixedDeltaTime;
+            }
+
             if (!isCollisionAllowed()) {
                 return;
             }

--- a/ValheimVRMod/Scripts/WeaponCollision.cs
+++ b/ValheimVRMod/Scripts/WeaponCollision.cs
@@ -291,22 +291,16 @@ namespace ValheimVRMod.Scripts {
                 Player.m_localPlayer.HaveStamina(getStaminaUsage() + 0.1f) && (attack.m_attackType == Attack.AttackType.Horizontal || !inCooldown);
             if (!canDoPrimaryAttack)
             {
-                if (!outline.enabled)
-                {
-                    outline.enabled = true;
-                }
+                outline.enabled = true;
                 outline.OutlineColor = Color.red;
                 outline.OutlineWidth = 5;
             }
             else if (postSecondaryAttackCountdown > 0.5f) {
-                if (!outline.enabled)
-                {
-                    outline.enabled = true;
-                }
+                outline.enabled = true;
                 outline.OutlineColor = Color.Lerp(new Color(1, 1, 0, 0), Color.yellow, postSecondaryAttackCountdown - 0.5f);
                 outline.OutlineWidth = 10;
             }
-            else if (outline.enabled)
+            else
             {
                 outline.enabled = false;
             }

--- a/ValheimVRMod/Utilities/RoomscaleSecondaryAttackUtils.cs
+++ b/ValheimVRMod/Utilities/RoomscaleSecondaryAttackUtils.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using UnityEngine;
+using ValheimVRMod.Scripts;
+
+namespace ValheimVRMod.Utilities
+{
+    public static class RoomscaleSecondaryAttackUtils
+    {
+        public static bool IsSecondaryAttack(WeaponCollision weaponCollision)
+        {
+            foreach (SecondaryAttackCheck check in secondaryAttackChecks)
+            {
+                if (check(weaponCollision))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private delegate bool SecondaryAttackCheck(WeaponCollision weaponCollision);
+
+        private static SecondaryAttackCheck[] secondaryAttackChecks = new SecondaryAttackCheck[] {
+            delegate(WeaponCollision weaponCollision) // Sword check
+            {
+                if (EquipScript.getRight() != EquipType.Sword)
+                {
+                    return false;
+                }
+
+                const float MIN_STAB_SPEED = 3.5f;
+                const float MIN_THRUST_DISTANCE = 1f;
+                const float MAX_STAB_ANGLE = 30;
+
+                float stabSpeed = Vector3.Dot(weaponCollision.mainHandPhysicsEstimator.GetAverageVelocityInSnapshots(), WeaponWield.weaponForward);
+                if (stabSpeed < MIN_STAB_SPEED)
+                {
+                    return false;
+                }
+
+                Vector3 thrust = weaponCollision.mainHandPhysicsEstimator == null ? Vector3.zero : weaponCollision.mainHandPhysicsEstimator.GetLongestLocomotion(1f);
+                if (Vector3.Dot(thrust, WeaponWield.weaponForward) < MIN_THRUST_DISTANCE)
+                {
+                    return false;
+                }
+
+                return Vector3.Angle(thrust, WeaponWield.weaponForward) <= MAX_STAB_ANGLE;
+            },
+            delegate (WeaponCollision weaponCollision) // Single-handed axe check
+            {
+                if (EquipScript.getRight() != EquipType.Axe || EquipScript.isTwoHandedAxeEquiped())
+                {
+                    return false;
+                }
+
+                // TODO: consider adjusting these constants to account for weapon length.
+                const float MIN_SPEED = 10f;
+                const float MIN_THRUST_DISTANCE = 1.8f;
+                const float MAX_ANGLE = 60;
+
+                Vector3 swingVelocity = weaponCollision.physicsEstimator.GetAverageVelocityInSnapshots();
+                Vector3 swingVelocityInPlayerCoordinates = Player.m_localPlayer.transform.InverseTransformVector(swingVelocity);
+                float speedDownAndForward = new Vector2(Mathf.Min(swingVelocityInPlayerCoordinates.y, 0), Mathf.Max(swingVelocityInPlayerCoordinates.z, 0)).magnitude;
+                if (speedDownAndForward < MIN_SPEED)
+                {
+                    return false;
+                }
+
+                Vector3 thrust = weaponCollision.physicsEstimator.GetLongestLocomotion(0.5f);
+                Vector3 thrustInPlayerCoordinates = Player.m_localPlayer.transform.InverseTransformVector(thrust);
+                float thrustDownAndFoward = new Vector2(Mathf.Min(thrustInPlayerCoordinates.y, 0), Mathf.Max(thrustInPlayerCoordinates.z, 0)).magnitude;
+                if (thrustDownAndFoward < MIN_THRUST_DISTANCE)
+                {
+                    return false;
+                }
+
+                return Vector3.Angle(thrust, swingVelocity) <= MAX_ANGLE;
+            },
+            delegate (WeaponCollision weaponCollision) // Two-handed axe check
+            {
+                return EquipScript.isTwoHandedAxeEquiped() && weaponCollision.lastAttackWasStab;
+            },
+            delegate (WeaponCollision weaponCollision) // Single-handed club check
+            {
+                if (EquipScript.getRight() != EquipType.Club || EquipScript.isTwoHandedClubEquiped())
+                {
+                    return false;
+                }
+
+                // TODO: consider adjusting these constants to account for weapon length.
+                const float MIN_SPEED = 10f;
+                const float MIN_THRUST_DISTANCE = 1.5f;
+                const float MAX_ANGLE = 60;
+
+                Vector3 swingVelocity = weaponCollision.physicsEstimator.GetAverageVelocityInSnapshots();
+                Vector3 swingVelocityInPlayerCoordinates = Player.m_localPlayer.transform.InverseTransformVector(swingVelocity);
+                float sagittalSpeed = new Vector2(swingVelocityInPlayerCoordinates.y, Mathf.Max(swingVelocityInPlayerCoordinates.z, 0)).magnitude;
+                if (sagittalSpeed < MIN_SPEED)
+                {
+                    return false;
+                }
+
+                Vector3 thrust = weaponCollision.physicsEstimator.GetLongestLocomotion(0.5f);
+                Vector3 thrustInPlayerCoordinates = Player.m_localPlayer.transform.InverseTransformVector(thrust);
+                float sagittalSpeedThrust = new Vector2(thrustInPlayerCoordinates.y, Mathf.Max(thrustInPlayerCoordinates.z, 0)).magnitude;
+                if (sagittalSpeedThrust < MIN_THRUST_DISTANCE)
+                {
+                    return false;
+                }
+
+                return Vector3.Angle(thrust, swingVelocity) <= MAX_ANGLE;
+            },
+            delegate (WeaponCollision weaponCollision) // Polearms check
+            {
+                if (EquipScript.getRight() != EquipType.Polearms) {
+                    return false;
+                }
+                    
+                const float MIN_SWIPING_SPEED = 5f;
+                float swipingSpeed = Vector3.ProjectOnPlane(weaponCollision.physicsEstimator.GetAverageVelocityInSnapshots(), WeaponWield.weaponForward).magnitude;
+                return !weaponCollision.lastAttackWasStab && swipingSpeed >= MIN_SWIPING_SPEED;
+            }
+
+        };
+    }
+}

--- a/ValheimVRMod/Utilities/RoomscaleSecondaryAttackUtils.cs
+++ b/ValheimVRMod/Utilities/RoomscaleSecondaryAttackUtils.cs
@@ -135,7 +135,6 @@ namespace ValheimVRMod.Utilities
 
             delegate (WeaponCollision weaponCollision) // Knife check
             {
-                LogUtils.LogWarning("Knife? " + (EquipScript.getRight() == EquipType.Knife) + " " + SteamVR_Actions.valheim_Grab.GetState(VRPlayer.dominantHandInputSource));
                 if (EquipScript.getRight() != EquipType.Knife || !SteamVR_Actions.valheim_Grab.GetState(VRPlayer.dominantHandInputSource)) {
                     return false;
                 }


### PR DESCRIPTION
Wield weapon in manner similar to the secondary attack animations in vanilla game to trigger a secondary attack. 

Sword: long stab (speed and distance required)
One-handed axe: long swing (speed and distance required)
One-handed club: long swing (speed and distance required)
Two-handed axe: stab
Atgeirs: fast swipe (speed required)

