### PR TITLE
Change secondary attack target outline to yellow; ignore multitarget damage penalty for two-handed weapon swipe

### DIFF
--- a/ValheimVRMod/Scripts/AttackTargetMeshCooldown.cs
+++ b/ValheimVRMod/Scripts/AttackTargetMeshCooldown.cs
@@ -3,10 +3,15 @@ using ValheimVRMod.Utilities;
 
 namespace ValheimVRMod.Scripts {
     public class AttackTargetMeshCooldown : MeshCooldown {
+        protected override Color FullOutlineColor { get { return isSecondaryAttackCooldown? Color.yellow : base.FullOutlineColor; } }
+
         public static float damageMultiplier;
         public static bool staminaDrained;
         public static bool durabilityDrained;
-        private static MeshCooldown primaryTargetMeshCooldown;
+        private static AttackTargetMeshCooldown primaryTargetMeshCooldown;
+
+        private bool isSecondaryAttackCooldown;
+
         public override bool tryTrigger(float cd) {
             bool isTriggered = base.tryTrigger(cd);
             if (isTriggered && primaryTargetMeshCooldown == null) {
@@ -14,6 +19,26 @@ namespace ValheimVRMod.Scripts {
                 damageMultiplier = 1;
             }
             return isTriggered;
+        }
+
+        public bool tryTriggerSecondaryAttack(float cd)
+        {
+            if (tryTrigger(cd))
+            {
+                isSecondaryAttackCooldown = true;
+                return true;
+            }
+            return false;
+        }
+
+        public bool tryTriggerPrimaryAttack(float cd)
+        {
+            if (tryTrigger(cd))
+            {
+                isSecondaryAttackCooldown = false;
+                return true;
+            }
+            return false;
         }
 
         public static float calcDamageMultiplier() {
@@ -26,6 +51,12 @@ namespace ValheimVRMod.Scripts {
                 damageMultiplier /= 2;
             }
 
+            WeaponCollision weaponCollision = Player.m_localPlayer.gameObject.GetComponentInChildren<WeaponCollision>();
+            if (weaponCollision && weaponCollision.twoHandedMultitargetSwipeCountdown > 0)
+            {
+                return 1;
+            }
+            
             return oldDamageMultiplier;
         }
 

--- a/ValheimVRMod/Scripts/MeshCooldown.cs
+++ b/ValheimVRMod/Scripts/MeshCooldown.cs
@@ -3,7 +3,7 @@ using ValheimVRMod.Utilities;
 
 namespace ValheimVRMod.Scripts {
     public class MeshCooldown : MonoBehaviour {
-        protected virtual Color FullOutlineColor { get; } = new Color(1, 0, 0, 1);
+        protected virtual Color FullOutlineColor { get; } = Color.red;
         private Color HiddenOutlineColor { get { return new Color(FullOutlineColor.r, FullOutlineColor.g, FullOutlineColor.b, 0); } }
 
         private float cooldownStart;

--- a/ValheimVRMod/Scripts/MeshCooldown.cs
+++ b/ValheimVRMod/Scripts/MeshCooldown.cs
@@ -3,9 +3,8 @@ using ValheimVRMod.Utilities;
 
 namespace ValheimVRMod.Scripts {
     public class MeshCooldown : MonoBehaviour {
-
-        private static readonly Color FullOutlineColor = Color.red;
-        private static readonly Color HiddenOutlineColor = new Color(1, 0, 0, 0);
+        protected virtual Color FullOutlineColor { get; } = new Color(1, 0, 0, 1);
+        private Color HiddenOutlineColor { get { return new Color(FullOutlineColor.r, FullOutlineColor.g, FullOutlineColor.b, 0); } }
 
         private float cooldownStart;
         private float cooldown;

--- a/ValheimVRMod/Scripts/WeaponCollision.cs
+++ b/ValheimVRMod/Scripts/WeaponCollision.cs
@@ -191,13 +191,13 @@ namespace ValheimVRMod.Scripts {
 
             if (isSecondaryAttack)
             {
-                // Use the target cooldown time of the primary attack if it is shorter to allow primary attack immediately after secondary attack;
-                // The secondary attack cooldown time is manage by postSecondaryAttackCountdown in this class intead.
+                // Use the target cooldown time of the primary attack if it is shorter to allow a primary attack immediately after secondary attack;
+                // The secondary attack cooldown time is managed by postSecondaryAttackCountdown in this class intead.
                 float targetCooldownTime = Mathf.Min(WeaponUtils.GetAttackDuration(attack), WeaponUtils.GetAttackDuration(secondaryAttack));
-                return attackTargetMeshCooldown.tryTrigger(targetCooldownTime);
+                return attackTargetMeshCooldown.tryTriggerSecondaryAttack(targetCooldownTime);
             }
             
-            return attackTargetMeshCooldown.tryTrigger(WeaponUtils.GetAttackDuration(attack));
+            return attackTargetMeshCooldown.tryTriggerPrimaryAttack(WeaponUtils.GetAttackDuration(attack));
         }
 
         private void OnRenderObject() {


### PR DESCRIPTION
Like in vanilla game, ignore multitarget damager penalty for the primary attack of batteaxes and secondary attack of atgeirs