### PR TITLE
Adjust bow accuracy calculation

### DIFF
--- a/ValheimVRMod/Patches/BowAndFishingPatches.cs
+++ b/ValheimVRMod/Patches/BowAndFishingPatches.cs
@@ -291,7 +291,7 @@ namespace ValheimVRMod.Patches {
         private static float recoilPushback = 0f;
         public static void Prefix(Attack __instance)
         {
-            if (__instance.m_character != Player.m_localPlayer)
+            if (__instance.m_character != Player.m_localPlayer || !VHVRConfig.UseVrControls())
             {
                 return;
             }
@@ -303,7 +303,7 @@ namespace ValheimVRMod.Patches {
         }
         public static void Postfix(Attack __instance)
         {
-            if (__instance.m_character != Player.m_localPlayer)
+            if (__instance.m_character != Player.m_localPlayer || !VHVRConfig.UseVrControls())
             {
                 return;
             }

--- a/ValheimVRMod/Patches/BowAndFishingPatches.cs
+++ b/ValheimVRMod/Patches/BowAndFishingPatches.cs
@@ -44,11 +44,12 @@ namespace ValheimVRMod.Patches {
                 return;
             }
 
-            if(__result > BowLocalManager.instance.lastDrawPercentage)
+            if(__result > BowLocalManager.instance.timeBasedChargePercentage)
             {
-                BowLocalManager.instance.lastDrawPercentage = __result;
+                BowLocalManager.instance.timeBasedChargePercentage = __result;
             }
 
+            // Only clamp the charge upon releasing, not during pulling.
             if (!BowLocalManager.instance.pulling)
             {
                 // Since the attack draw percentage is not patched in the prefix, we need to clamp it here in case the real life pull percentage is smaller than the unpatched attack draw percentage.
@@ -194,23 +195,34 @@ namespace ValheimVRMod.Patches {
     class PatchFireProjectileBurst {
         
         static void Prefix(ref Attack __instance, ref ItemDrop.ItemData ___m_ammoItem, Humanoid ___m_character) {
-           
             if (___m_character != Player.m_localPlayer || !VHVRConfig.UseVrControls()) {
                 return;
             }
 
-            
-            
+
+
             __instance.m_useCharacterFacing = false;
             __instance.m_launchAngle = 0;
 
             if (VHVRConfig.RestrictBowDrawSpeed() != "None" && EquipScript.getLeft() == EquipType.Bow) {
-                if (VHVRConfig.IsBowAccuracyBasedOnCharge())
+                if (VHVRConfig.BowAccuracyIgnoresDrawLength())
                 {
-                    __instance.m_projectileAccuracyMin = __instance.m_projectileAccuracyMin - __instance.m_projectileAccuracyMin * BowLocalManager.instance.lastDrawPercentage;
+
+                    float currentSpreadFactor = 1 - Mathf.Sqrt(BowLocalManager.instance.GetAttackPercentage());
+                    if (currentSpreadFactor <= 0)
+                    {
+                        return;
+                    }
+
+                    float desiredSpreadFactor = 1 - Mathf.Sqrt(BowLocalManager.instance.timeBasedChargePercentage);
+                    float accuracyAdjustment = desiredSpreadFactor / currentSpreadFactor;
+                    float minSpread = __instance.m_projectileAccuracy;
+
+                    // We scale the max spread (i. e. m_projectileAccuracyMin) to compensate for the difference between desiredSpreadFactor and currentSpreadFactor.
+                    __instance.m_projectileAccuracyMin = Mathf.Lerp(minSpread, __instance.m_projectileAccuracyMin, accuracyAdjustment);
                     if (___m_ammoItem != null)
                     {
-                        ___m_ammoItem.m_shared.m_attack.m_projectileAccuracyMin = ___m_ammoItem.m_shared.m_attack.m_projectileAccuracyMin - ___m_ammoItem.m_shared.m_attack.m_projectileAccuracyMin * BowLocalManager.instance.lastDrawPercentage;
+                        ___m_ammoItem.m_shared.m_attack.m_projectileAccuracyMin = Mathf.Lerp(___m_ammoItem.m_shared.m_attack.m_projectileAccuracy, ___m_ammoItem.m_shared.m_attack.m_projectileAccuracyMin, accuracyAdjustment);
                     }
                 }
                 return;
@@ -279,7 +291,7 @@ namespace ValheimVRMod.Patches {
         private static float recoilPushback = 0f;
         public static void Prefix(Attack __instance)
         {
-            if (__instance.m_character != Player.m_localPlayer || !VHVRConfig.UseVrControls())
+            if (__instance.m_character != Player.m_localPlayer)
             {
                 return;
             }
@@ -291,7 +303,7 @@ namespace ValheimVRMod.Patches {
         }
         public static void Postfix(Attack __instance)
         {
-            if (__instance.m_character != Player.m_localPlayer || !VHVRConfig.UseVrControls())
+            if (__instance.m_character != Player.m_localPlayer)
             {
                 return;
             }

--- a/ValheimVRMod/Scripts/BowManager.cs
+++ b/ValheimVRMod/Scripts/BowManager.cs
@@ -33,6 +33,7 @@ namespace ValheimVRMod.Scripts {
         private Vector3 restingStringBottomInObjectSpace = new Vector3(0, Mathf.Infinity, 0);
         private Vector3 bowUpInObjectSpace;
         private Vector3 bowRightInObjectSpace;
+        private float stringLength;
 
         protected readonly Quaternion originalRotation = new Quaternion(0.4763422f, 0.420751f, 0.5951466f, 0.4918001f); // Euler Angles: 358.1498 78.91683 99.33968
         protected Transform pullStart;
@@ -50,7 +51,7 @@ namespace ValheimVRMod.Scripts {
         private bool wasPulling;
         protected bool oneHandedAiming = false;
         public static float realLifePullPercentage;
-        public float lastDrawPercentage;
+        public float timeBasedChargePercentage;
         public bool pulling;
 
         void Awake() {
@@ -219,6 +220,7 @@ namespace ValheimVRMod.Scripts {
             stringBottom.SetParent(lowerLimbBone, false);
             stringTop.position = transform.TransformPoint(restingStringTopInObjectSpace);
             stringBottom.position = transform.TransformPoint(restingStringBottomInObjectSpace);
+            stringLength = bowOrientation.InverseTransformVector(stringTop.position - stringBottom.position).magnitude;
             pullStart = new GameObject().transform;
             pullStart.parent = bowOrientation;
             pullStart.position = Vector3.Lerp(stringTop.position, stringBottom.position, 0.5f);
@@ -347,7 +349,7 @@ namespace ValheimVRMod.Scripts {
 
             if (pulling) {
                 if (!wasPulling) {
-                    lastDrawPercentage = 0;
+                    timeBasedChargePercentage = 0;
                     wasPulling = true;
                 }
 
@@ -389,7 +391,7 @@ namespace ValheimVRMod.Scripts {
             }
             float pullDelta = pullStart.localPosition.z - pullObj.transform.localPosition.z;
             // Just a heuristic and simplified approximation for the bend angle.
-            float bendAngleDegrees = pullDelta <= 0 ? 0 : Mathf.Asin(Math.Min(1, pullDelta)) * 180 / Mathf.PI;
+            float bendAngleDegrees = pullDelta <= 0 ? 0 : Mathf.Asin(Math.Min(1, pullDelta * 1.25f / stringLength)) * 180 / Mathf.PI;
 
             upperLimbBone.localRotation = Quaternion.Euler(-bendAngleDegrees, 0, 0);
             lowerLimbBone.localRotation = Quaternion.Euler(bendAngleDegrees, 0, 0);

--- a/ValheimVRMod/Utilities/VHVRConfig.cs
+++ b/ValheimVRMod/Utilities/VHVRConfig.cs
@@ -133,7 +133,7 @@ namespace ValheimVRMod.Utilities
         private static ConfigEntry<string> arrowRestSide;
         private static ConfigEntry<string> bowDrawRestrictType;
         private static ConfigEntry<float> bowDrawRange;
-        private static ConfigEntry<bool> bowAccuracyBasedOnCharge;
+        private static ConfigEntry<bool> bowAccuracyIgnoresDrawLength;
         private static ConfigEntry<float> bowStaminaAdjust;
         private static ConfigEntry<string> crossbowSaggitalRotationSource;
         private static ConfigEntry<bool> crossbowManualReload;
@@ -720,10 +720,10 @@ namespace ValheimVRMod.Utilities
                 new ConfigDescription("Adjust the range of the max bow draw, lower value make it useful for controller with inside out tracking",
                 new AcceptableValueRange<float>(0.3f, 0.7f)));
 
-            bowAccuracyBasedOnCharge = config.Bind("Motion Control",
-                                                    "BowAccuracyBasedOnCharge",
+            bowAccuracyIgnoresDrawLength = config.Bind("Motion Control",
+                                                    "BowAccuracyIgnoresDrawLength",
                                                     true,
-                                                    "Use Vanilla bow draw charge as accuracy multiplier instead of real draw range, if set to false, the accuracy would be based on draw range");
+                                                    "Use charging time instead of draw length to determine bow accuracy");
 
             bowStaminaAdjust = config.Bind("Motion Control",
                 "BowStaminaAdjust",
@@ -1439,9 +1439,9 @@ namespace ValheimVRMod.Utilities
             return bhapticsEnabled.Value && !NonVrPlayer();
         }
 
-        public static bool IsBowAccuracyBasedOnCharge()
+        public static bool BowAccuracyIgnoresDrawLength()
         {
-            return bowAccuracyBasedOnCharge.Value;
+            return bowAccuracyIgnoresDrawLength.Value;
         }
         public static float GetBowMaxDrawRange()
         {


### PR DESCRIPTION
Adjust bow accuracy calculation to avoid having the arrow spread smaller than it should be;

Adjust bow bending angle to make it look more realistic.