### PR TITLE
Make all equip only sheathe on button release

### DIFF
--- a/ValheimVRMod/Utilities/Pose.cs
+++ b/ValheimVRMod/Utilities/Pose.cs
@@ -73,9 +73,10 @@ namespace ValheimVRMod.Utilities {
         }
         
         private static bool isUnpressSheath() {
-            return isBuildingTool() 
-                   || isHoldingThrowable();
+            return true;
         }
+
+        //reserved in case we need it later
         private static bool isHoldingThrowable() {
             return EquipScript.getRight() == EquipType.Spear 
                    || EquipScript.getRight() == EquipType.SpearChitin

--- a/ValheimVRMod/Utilities/Pose.cs
+++ b/ValheimVRMod/Utilities/Pose.cs
@@ -74,6 +74,8 @@ namespace ValheimVRMod.Utilities {
         
         private static bool isUnpressSheath() {
             return true;
+            //return isBuildingTool()
+            //       || isHoldingThrowable();
         }
 
         //reserved in case we need it later


### PR DESCRIPTION
- since logically you sheathe a weapon by releasing it
- mainly to not sheathing it accidentally when pressing grab from behind while doing secondary attack