### PR TITLE
Fix terrain rendering

### DIFF
--- a/ValheimVRMod/Patches/Misc.cs
+++ b/ValheimVRMod/Patches/Misc.cs
@@ -8,6 +8,7 @@ using HarmonyLib;
 using Valve.VR;
 using UnityEngine;
 using ValheimVRMod.Utilities;
+using UnityEngine.Rendering;
 
 using static ValheimVRMod.Utilities.LogUtils;
 
@@ -298,4 +299,31 @@ namespace ValheimVRMod.Patches
             }
         }
     }
+
+    [HarmonyPatch(typeof(Heightmap), nameof(Heightmap.Render))]
+    class HMR
+    {
+        static bool Prefix(Heightmap __instance)
+        {
+            ShadowCastingMode shadowCastingMode;
+            bool flag;
+            if (__instance.m_renderMesh)
+            {
+                if (!__instance.m_isDistantLod)
+                {
+                    shadowCastingMode = (Heightmap.EnableDistantTerrainShadows ? ShadowCastingMode.On : ShadowCastingMode.TwoSided);
+                    flag = true;
+                }
+                else
+                {
+                    shadowCastingMode = (Heightmap.EnableDistantTerrainShadows ? ShadowCastingMode.On : ShadowCastingMode.Off);
+                    flag = false;
+                }
+                Matrix4x4 matrix4x4 = Matrix4x4.TRS(__instance.gameObject.transform.position, Quaternion.identity, Vector3.one);
+                Graphics.DrawMesh(__instance.m_renderMesh, matrix4x4, __instance.m_materialInstance, __instance.gameObject.layer, Utils.GetMainCamera(), 0, new MaterialPropertyBlock(), shadowCastingMode, flag);
+            }
+            return false;
+        }
+    }
+
 }

--- a/ValheimVRMod/Patches/Misc.cs
+++ b/ValheimVRMod/Patches/Misc.cs
@@ -300,11 +300,16 @@ namespace ValheimVRMod.Patches
         }
     }
 
+    // Pass correct camera to Graphics.DrawMesh
     [HarmonyPatch(typeof(Heightmap), nameof(Heightmap.Render))]
-    class HMR
+    class HeightMapRenderPatch
     {
         static bool Prefix(Heightmap __instance)
         {
+            if (VHVRConfig.NonVrPlayer())
+            {
+                return true;
+            }
             ShadowCastingMode shadowCastingMode;
             bool flag;
             if (__instance.m_renderMesh)


### PR DESCRIPTION
The vanilla logic passes Camera.current to Graphics.DrawMesh, which doesn't get the right camera reference. We replace it with Utils.GetMainCamera instead.