### PR TITLE
Use the position of the VR mouse cursor to find the hovered element in the inventory grid

### DIFF
--- a/ValheimVRMod/Patches/ControlPatches.cs
+++ b/ValheimVRMod/Patches/ControlPatches.cs
@@ -688,7 +688,7 @@ namespace ValheimVRMod.Patches {
         }
     }
 
-    [HarmonyPatch(typeof(InventoryGrid), "GetHoveredElement")]
+    [HarmonyPatch(typeof(InventoryGrid), nameof(InventoryGrid.GetHoveredElement))]
     static class InventoryGrid_GetHoveredElement_Patch
     {
         static bool Prefix(InventoryGrid __instance, ref InventoryGrid.Element __result)

--- a/ValheimVRMod/Patches/ControlPatches.cs
+++ b/ValheimVRMod/Patches/ControlPatches.cs
@@ -693,6 +693,10 @@ namespace ValheimVRMod.Patches {
     {
         static bool Prefix(InventoryGrid __instance, ref InventoryGrid.Element __result)
         {
+            if (!VHVRConfig.UseVrControls()) {
+                return true;
+            }
+
             foreach (InventoryGrid.Element element in __instance.m_elements)
             {
                 RectTransform rectTransform = element.m_go.transform as RectTransform;

--- a/ValheimVRMod/Patches/ControlPatches.cs
+++ b/ValheimVRMod/Patches/ControlPatches.cs
@@ -687,7 +687,28 @@ namespace ValheimVRMod.Patches {
                 mod = InventoryGrid.Modifier.Move;
         }
     }
-    
+
+    [HarmonyPatch(typeof(InventoryGrid), "GetHoveredElement")]
+    static class InventoryGrid_GetHoveredElement_Patch
+    {
+        static bool Prefix(InventoryGrid __instance, ref InventoryGrid.Element __result)
+        {
+            foreach (InventoryGrid.Element element in __instance.m_elements)
+            {
+                RectTransform rectTransform = element.m_go.transform as RectTransform;
+                // Use SoftwareCursor.ScaledMouseVector() instead of the vanilla Input.mousePosition to support VR GUI.
+                Vector2 point = rectTransform.InverseTransformPoint(SoftwareCursor.ScaledMouseVector());
+                if (rectTransform.rect.Contains(point))
+                {
+                    __result = element;
+                    return false;
+                }
+            }
+            __result = null;
+            return false;
+        }
+    }
+
     // This patch enables adding map pins without needing to "Double Click".
     // Instead it is triggered using the "click modifier" plus a single left click.
     [HarmonyPatch(typeof(Minimap), nameof(Minimap.OnMapLeftClick))]


### PR DESCRIPTION
Fixes the bug that tooltips are sometimes empty for hovered items in the inventory.