### PR TITLE
Weapon holstering refactor and fix

### DIFF
--- a/ValheimVRMod/Patches/InteractionPatches.cs
+++ b/ValheimVRMod/Patches/InteractionPatches.cs
@@ -17,7 +17,15 @@ namespace ValheimVRMod.Patches
     {
         
         private static MethodInfo setupVisEquipmentMethod = AccessTools.Method(typeof(Humanoid), "SetupVisEquipment");
-        
+        private static bool allowHidingDominantHandItem = true;
+        private static bool allowHidingNonDominantHandItem = true;
+
+        public static void HideLocalPlayerHandItem(bool isDominantHand) {
+            allowHidingDominantHandItem = isDominantHand;
+            allowHidingNonDominantHandItem = !isDominantHand;
+            Player.m_localPlayer.HideHandItems();
+        }
+
         static bool Prefix(ref Humanoid __instance,
             ref ItemDrop.ItemData ___m_leftItem, ref ItemDrop.ItemData ___m_rightItem, 
             ref ItemDrop.ItemData ___m_hiddenLeftItem, ref ItemDrop.ItemData ___m_hiddenRightItem, 
@@ -27,23 +35,23 @@ namespace ValheimVRMod.Patches
                 return true;
             }
             
-            bool leftHand = Pose.toggleShowLeftHand;
-            bool rightHand = Pose.toggleShowRightHand;
-            
-            Pose.toggleShowRightHand = true;
-            Pose.toggleShowLeftHand = true;
+            bool hideDominantHandItem = allowHidingDominantHandItem;
+            bool hidingNonDominantHandItem = allowHidingNonDominantHandItem;
+
+            allowHidingDominantHandItem = true;
+            allowHidingNonDominantHandItem = true;
     
             if (___m_leftItem == null && ___m_rightItem == null) {
                 return false;   
             }
     
-            if (leftHand) {
+            if (hidingNonDominantHandItem) {
                 ItemDrop.ItemData leftItem = ___m_leftItem;
                 __instance.UnequipItem(___m_leftItem);
                 ___m_hiddenLeftItem = leftItem;
             }
     
-            if (rightHand) {
+            if (hideDominantHandItem) {
                 ItemDrop.ItemData rightItem = ___m_rightItem;
                 __instance.UnequipItem(___m_rightItem);
                 ___m_hiddenRightItem = rightItem;                
@@ -60,7 +68,16 @@ namespace ValheimVRMod.Patches
     [HarmonyPatch(typeof(Humanoid), "ShowHandItems")]
     class PatchShowHandItems
     {
-    
+        private static bool allowShowingDominantHandItem = true;
+        private static bool allowShowingNonDominantHandItem = true;
+
+        public static void ShowLocalPlayerHandItem(bool isDominantHand)
+        {
+            allowShowingDominantHandItem = isDominantHand;
+            allowShowingNonDominantHandItem = !isDominantHand;
+            Player.m_localPlayer.ShowHandItems();
+        }
+
         static bool Prefix(ref Humanoid __instance,
             ref ItemDrop.ItemData ___m_hiddenLeftItem, ref ItemDrop.ItemData ___m_hiddenRightItem,
             ref ZSyncAnimation ___m_zanim)
@@ -70,17 +87,17 @@ namespace ValheimVRMod.Patches
                 return true;
             }
     
-            bool leftHand = Pose.toggleShowLeftHand;
-            bool rightHand = Pose.toggleShowRightHand;
-            
-            Pose.toggleShowRightHand = true;
-            Pose.toggleShowLeftHand = true;
+            bool showDominantHandItem = allowShowingDominantHandItem;
+            bool showNonDominantHandItem = allowShowingNonDominantHandItem;
+
+            allowShowingDominantHandItem = true;
+            allowShowingNonDominantHandItem = true;
             
             if (___m_hiddenLeftItem == null && ___m_hiddenRightItem == null) {
                 return false;   
             }
     
-            if (leftHand) {
+            if (showNonDominantHandItem) {
                 ItemDrop.ItemData hiddenLeftItem =___m_hiddenLeftItem;
                 ___m_hiddenLeftItem = null;
                 if (hiddenLeftItem != null) {
@@ -91,7 +108,7 @@ namespace ValheimVRMod.Patches
                 }
             }
     
-            if (rightHand)
+            if (showDominantHandItem)
             {
                 ItemDrop.ItemData hiddenRightItem = ___m_hiddenRightItem;
                 ___m_hiddenRightItem = null;

--- a/ValheimVRMod/Utilities/Pose.cs
+++ b/ValheimVRMod/Utilities/Pose.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using ValheimVRMod.Patches;
 using ValheimVRMod.Scripts;
 using ValheimVRMod.VRCore;
 using ValheimVRMod.VRCore.UI;
@@ -7,29 +8,26 @@ using Valve.VR.InteractionSystem;
 
 namespace ValheimVRMod.Utilities {
     public static class Pose {
-        public const bool ALWAYS_USE_UNPRESS_SHEATH = true;
-        public static bool toggleShowLeftHand = true;
-        public static bool toggleShowRightHand = true;
-        public static bool justUnsheathed;
+        private const bool ALWAYS_USE_UNPRESS_SHEATH = true;
+
+        private static bool justUnsheathed;
 
         public static void checkInteractions()
         {
-            
             if (Player.m_localPlayer == null || !VRControls.mainControlsActive)
             {
                 return;
             }
 
-            checkHandOverShoulder(true, ref toggleShowLeftHand);
-            checkHandOverShoulder(false, ref toggleShowRightHand);
-
+            checkHandOverShoulder(isDominantHand: true);
+            checkHandOverShoulder(isDominantHand: false);
         }
         
-        private static void checkHandOverShoulder(bool isRightHand, ref bool toggleShowHand)
+        private static void checkHandOverShoulder(bool isDominantHand)
         {
-            var isMainHand = isRightHand ^ VHVRConfig.LeftHanded();
-            var inputSource = isMainHand ? SteamVR_Input_Sources.RightHand : SteamVR_Input_Sources.LeftHand;
-            var hand = isMainHand ? VRPlayer.rightHand : VRPlayer.leftHand;
+            var isRightHand = isDominantHand ^ VHVRConfig.LeftHanded();
+            var inputSource = isRightHand ? SteamVR_Input_Sources.RightHand : SteamVR_Input_Sources.LeftHand;
+            var hand = isRightHand ? VRPlayer.rightHand : VRPlayer.leftHand;
             
             var camera = CameraUtils.getCamera(CameraUtils.VR_CAMERA).transform;
             var action = SteamVR_Actions.valheim_Grab;
@@ -40,38 +38,37 @@ namespace ValheimVRMod.Utilities {
                 if (action.GetStateDown(inputSource))
                 {
 
-                    if(isRightHand && isHoldingItem(isRightHand) && isUnpressSheath()) {
+                    if(isDominantHand && isHoldingItem(isDominantHand) && isUnpressSheath()) {
                         return;
                     } 
                  
-                    toggleShowHand = false;
                     hand.hapticAction.Execute(0, 0.2f, 100, 0.3f, inputSource);
                     
-                    if (isRightHand && EquipScript.getLeft() == EquipType.Bow) {
+                    if (isDominantHand && EquipScript.getLeft() == EquipType.Bow) {
                         BowLocalManager.instance.toggleArrow();
-                    } else if (isHoldingItem(isRightHand)) {
-                        Player.m_localPlayer.HideHandItems();
+                    } else if (isHoldingItem(isDominantHand)) {
+                        PatchHideHandItems.HideLocalPlayerHandItem(isDominantHand);
                     } else {
-                        Player.m_localPlayer.ShowHandItems();
+                        PatchShowHandItems.ShowLocalPlayerHandItem(isDominantHand);
                         justUnsheathed = true;
                     }
                 }
-                else if (!justUnsheathed && isRightHand && action.GetStateUp(inputSource)) {
-                    if (isHoldingItem(isRightHand) && isUnpressSheath()) {
-                        Player.m_localPlayer.HideHandItems();
+                else if (!justUnsheathed && isDominantHand && action.GetStateUp(inputSource)) {
+                    if (isHoldingItem(isDominantHand) && isUnpressSheath()) {
+                        PatchHideHandItems.HideLocalPlayerHandItem(isDominantHand);
                     }
                 }
             }
-            if (justUnsheathed && isRightHand && action.GetStateUp(inputSource)&& isUnpressSheath()) {
+            if (justUnsheathed && isDominantHand && action.GetStateUp(inputSource) && isUnpressSheath()) {
                 justUnsheathed = false;
             }
         }
         
-        private static bool isHoldingItem(bool isRightHand) {
-            return isRightHand && Player.m_localPlayer.GetRightItem() != null
-                   || !isRightHand && Player.m_localPlayer.GetLeftItem() != null;
+        private static bool isHoldingItem(bool isDominantHand) {
+            return isDominantHand && Player.m_localPlayer.GetRightItem() != null
+                   || !isDominantHand && Player.m_localPlayer.GetLeftItem() != null;
         }
-        
+
         private static bool isUnpressSheath() {
             // TODO: remove this method and clean up if it always returns true.
             return ALWAYS_USE_UNPRESS_SHEATH


### PR DESCRIPTION
Refactor and fix the bug that trying holstering dominant hand weapon will cause non-dominant hand equipment to be holstered as well.