### PR TITLE
Remove HeightMapRenderPatch

### DIFF
--- a/ValheimVRMod/Patches/Misc.cs
+++ b/ValheimVRMod/Patches/Misc.cs
@@ -299,36 +299,4 @@ namespace ValheimVRMod.Patches
             }
         }
     }
-
-    // Pass correct camera to Graphics.DrawMesh
-    [HarmonyPatch(typeof(Heightmap), nameof(Heightmap.Render))]
-    class HeightMapRenderPatch
-    {
-        static bool Prefix(Heightmap __instance)
-        {
-            if (VHVRConfig.NonVrPlayer())
-            {
-                return true;
-            }
-            ShadowCastingMode shadowCastingMode;
-            bool flag;
-            if (__instance.m_renderMesh)
-            {
-                if (!__instance.m_isDistantLod)
-                {
-                    shadowCastingMode = (Heightmap.EnableDistantTerrainShadows ? ShadowCastingMode.On : ShadowCastingMode.TwoSided);
-                    flag = true;
-                }
-                else
-                {
-                    shadowCastingMode = (Heightmap.EnableDistantTerrainShadows ? ShadowCastingMode.On : ShadowCastingMode.Off);
-                    flag = false;
-                }
-                Matrix4x4 matrix4x4 = Matrix4x4.TRS(__instance.gameObject.transform.position, Quaternion.identity, Vector3.one);
-                Graphics.DrawMesh(__instance.m_renderMesh, matrix4x4, __instance.m_materialInstance, __instance.gameObject.layer, Utils.GetMainCamera(), 0, new MaterialPropertyBlock(), shadowCastingMode, flag);
-            }
-            return false;
-        }
-    }
-
 }


### PR DESCRIPTION
Remove this patch since 1) HeightMap#Render() no longer exists and 2) this patch is no longer needed for terrain rendering.