### PR TITLE
Fix broken tooltips in keyboard+mouse mode

### DIFF
--- a/ValheimVRMod/Patches/ControlPatches.cs
+++ b/ValheimVRMod/Patches/ControlPatches.cs
@@ -726,10 +726,6 @@ namespace ValheimVRMod.Patches {
     {
         static bool Prefix(InventoryGrid __instance, ref InventoryGrid.Element __result)
         {
-            if (!VHVRConfig.UseVrControls()) {
-                return true;
-            }
-
             foreach (InventoryGrid.Element element in __instance.m_elements)
             {
                 RectTransform rectTransform = element.m_go.transform as RectTransform;


### PR DESCRIPTION
Enable the patch that uses SoftwareCursor.ScaledMouseVector() instead of the vanilla Input.mousePosition for keyboard+mouse mode.