### PR TITLE
Auto-select bolt when equipping crossbow

### DIFF
--- a/ValheimVRMod/Patches/EquipPatches.cs
+++ b/ValheimVRMod/Patches/EquipPatches.cs
@@ -160,18 +160,13 @@ namespace ValheimVRMod.Patches {
             switch (EquipScript.getLeft()) {
                 case EquipType.Bow:
                     meshFilter.gameObject.AddComponent<BowLocalManager>();
-                    var bow = Player.m_localPlayer.GetLeftItem();
-                    if (!Attack.HaveAmmo(Player.m_localPlayer, bow))
-                    {
-                        return;
-                    }
-                    Attack.EquipAmmoItem(Player.m_localPlayer, bow);
-                    
+                    EquipScript.equipAmmo();                   
                     return;
                 case EquipType.Crossbow:
                     CrossbowManager crossbowManager = ___m_leftItemInstance.AddComponent<CrossbowManager>();
                     crossbowManager.Initialize(Player.m_localPlayer.GetLeftItem(), ___m_leftItem);
                     crossbowManager.gameObject.AddComponent<WeaponBlock>().weaponWield = crossbowManager;
+                    EquipScript.equipAmmo();
                     return;
                 case EquipType.Lantern:
                     // TODO: implement a component that makes dverger lantern hangs downward regardless of hand orientation.

--- a/ValheimVRMod/Scripts/CrossbowMorphManager.cs
+++ b/ValheimVRMod/Scripts/CrossbowMorphManager.cs
@@ -361,12 +361,11 @@ namespace ValheimVRMod.Scripts {
              var ammoItem = Player.m_localPlayer.GetAmmoItem();
              
              if (ammoItem == null || ammoItem.m_shared.m_itemType != ItemDrop.ItemData.ItemType.Ammo) {
-                 // out of ammo
-                 if (!Attack.HaveAmmo(Player.m_localPlayer, weapon))
-                 {
-                     return false;
-                 }
-                 Attack.EquipAmmoItem(Player.m_localPlayer, weapon);
+                bool hasAmmo = EquipScript.equipAmmo();
+                if (!hasAmmo)
+                {
+                    return false;
+                }
              }
              
              bolt = Instantiate(ammoItem.m_shared.m_attack.m_attackProjectile, boltAttach.transform);

--- a/ValheimVRMod/Utilities/EquipScript.cs
+++ b/ValheimVRMod/Utilities/EquipScript.cs
@@ -203,6 +203,24 @@ namespace ValheimVRMod.Utilities
             return EquipType.None;
         }
 
+        public static bool equipAmmo()
+        {
+            if (getLeft() != EquipType.Bow && getLeft() != EquipType.Crossbow)
+            {
+                LogUtils.LogWarning("Attempting to equip ammo without bow or crossbow equipped");
+                return false;
+            }
+                
+            ItemDrop.ItemData weapon = Player.m_localPlayer.GetLeftItem();
+            if (Attack.HaveAmmo(Player.m_localPlayer, weapon))
+            {
+                Attack.EquipAmmoItem(Player.m_localPlayer, weapon);
+                return true;
+            }
+
+            return false;
+        }
+
         public static bool isThrowable(ItemDrop.ItemData item)
         {
             if (item != null)


### PR DESCRIPTION
Auto-select bolt when equipping crossbow. Fixes the bug that switching from bow to crossobw allows loading arrow (instead of bolt) onto the crossbow.