### PR TITLE
Support Fix For the newly maintained Valheim Raft

### DIFF
--- a/ValheimVRMod/Patches/EyeRotationPatch.cs
+++ b/ValheimVRMod/Patches/EyeRotationPatch.cs
@@ -298,17 +298,17 @@ namespace ValheimVRMod.Patches
                 if (!player.IsAttached())
                 {
                     var ship = player.GetStandingOnShip();
-                    var moveableBase = player.transform.parent;
-                    if (ship || (moveableBase && moveableBase?.name == "MoveableBase"))
+                    var movableBase = player.transform.parent;
+                    if (ship || (movableBase && movableBase?.name == "MovableBase"))
                     {
                         Transform referenceUp = null;
                         if (ship)
                         {
                             referenceUp = ship.transform;
                         }
-                        else if (moveableBase && moveableBase?.name == "MoveableBase")
+                        else if (movableBase && movableBase?.name == "MovableBase")
                         {
-                            referenceUp = moveableBase.transform;
+                            referenceUp = movableBase.transform;
                         }
 
                         if (referenceUp == null)

--- a/ValheimVRMod/Patches/HandBasedInteractionPatches.cs
+++ b/ValheimVRMod/Patches/HandBasedInteractionPatches.cs
@@ -191,8 +191,8 @@ namespace ValheimVRMod.Patches
                             hoverReference = raycastHit.collider.gameObject;
                             return;
                         }
-                        //MoveableBase is the gameobject name for Valheim Raft Mod object
-                        if (raycastHit.collider.attachedRigidbody && raycastHit.collider.attachedRigidbody.name == "MoveableBase")
+                        //MovableBase is the gameobject name for Valheim Raft Mod object
+                        if (raycastHit.collider.attachedRigidbody && raycastHit.collider.attachedRigidbody.name == "MovableBase")
                         {
                             hoverReference = raycastHit.collider.gameObject;
                             return;

--- a/ValheimVRMod/Scripts/BuildingManager.cs
+++ b/ValheimVRMod/Scripts/BuildingManager.cs
@@ -459,12 +459,12 @@ namespace ValheimVRMod.Scripts
                     originalRayTraceTransform = pieceRaycast.transform;
                     if (modSupport)
                     {
-                        if (pieceRaycast.transform.name == "MoveableBase")
+                        if (pieceRaycast.transform.name == "MovableBase")
                         {
                             originalRayTraceMod = pieceRaycast.transform;
                             originalRayTraceTransform = pieceRaycast.collider.transform;
                         }
-                        else if (pieceRaycast.transform && (SteamVR_Actions.laserPointers_LeftClick.GetStateDown(SteamVR_Input_Sources.RightHand) || !(Player.m_localPlayer.transform.parent && Player.m_localPlayer.transform.parent.name == "MoveableBase")))
+                        else if (pieceRaycast.transform && (SteamVR_Actions.laserPointers_LeftClick.GetStateDown(SteamVR_Input_Sources.RightHand) || !(Player.m_localPlayer.transform.parent && Player.m_localPlayer.transform.parent.name == "MovableBase")))
                         {
                             originalRayTraceMod = null;
                         }
@@ -478,7 +478,7 @@ namespace ValheimVRMod.Scripts
                     snapLine.enabled = true;
                     snapLine.positionCount = 2;
                     originalRayTraceTransform = null;
-                    if (!(Player.m_localPlayer.transform.parent && Player.m_localPlayer.transform.parent.name == "MoveableBase"))
+                    if (!(Player.m_localPlayer.transform.parent && Player.m_localPlayer.transform.parent.name == "MovableBase"))
                     {
                         originalRayTraceMod = null;
                     }
@@ -651,7 +651,7 @@ namespace ValheimVRMod.Scripts
             if (modSupport)
             {
                 var raft = pieceRaycast.transform;
-                if (raft.name == "MoveableBase")
+                if (raft.name == "MovableBase")
                 {
                     buildRefBox.transform.SetParent(raft);
                 }
@@ -688,7 +688,7 @@ namespace ValheimVRMod.Scripts
             var forward = Vector3.forward;
             if (modSupport)
             {
-                if (rayTracedPiece && rayTracedPiece.transform.parent && rayTracedPiece.transform.parent.name == "MoveableBase")
+                if (rayTracedPiece && rayTracedPiece.transform.parent && rayTracedPiece.transform.parent.name == "MovableBase")
                 {
                     forward = rayTracedPiece.transform.parent.forward;
                 }
@@ -802,7 +802,7 @@ namespace ValheimVRMod.Scripts
                         firstSnapTransform = pieceRaycast.transform;
                         if (modSupport)
                         {
-                            if (firstSnapTransform.transform.name == "MoveableBase")
+                            if (firstSnapTransform.transform.name == "MovableBase")
                             {
                                 lastSnapMod = pieceRaycast.transform;
                                 firstSnapTransform = pieceRaycast.collider.transform;


### PR DESCRIPTION
- fix for Valheim raft that newly maintained

link for the mod :
https://valheim.thunderstore.io/package/zolantris/ValheimRAFT/ 
https://www.nexusmods.com/valheim/mods/2630

Basically it just renamed of the object from `MoveableBase` to `MovableBase`