### PR TITLE
Add Modded melee weapon support 

### DIFF
--- a/ValheimVRMod/Scripts/WeaponCollision.cs
+++ b/ValheimVRMod/Scripts/WeaponCollision.cs
@@ -37,7 +37,7 @@ namespace ValheimVRMod.Scripts
         public static bool isDrinking;
         public LocalWeaponWield weaponWield;
         public static bool isLastHitOnTerrain;
-        private bool isCustom = false;
+        private float isCustom = 0;
 
         private static readonly int[] ignoreLayers = {
             LayerUtils.WATERVOLUME_LAYER,
@@ -249,11 +249,14 @@ namespace ValheimVRMod.Scripts
             transform.SetParent(Player.m_localPlayer.transform, true);
 
             //Late update since the weapon position and rotation isnt the same at awake (need more later update)
-            if (isCustom)
+            if (isCustom == 50)
             {
-                colliderParent.transform.LookAt(colliderParent.transform.position + LocalWeaponWield.weaponForward,VRPlayer.dominantHandRayDirection);
-                colliderParent.transform.position = VRPlayer.dominantHand.transform.position + (LocalWeaponWield.weaponForward * item.m_shared.m_attack.m_attackRange * 0.25f);
-                isCustom = false;
+                isCustom = -100;
+            }
+            else if (isCustom >= 0)
+            {
+                UpdateCustomHitBox();
+                isCustom += 1;
             }
         }
 
@@ -289,7 +292,7 @@ namespace ValheimVRMod.Scripts
                 colliderParent.transform.localPosition = colliderData.pos;
                 colliderParent.transform.localRotation = Quaternion.Euler(colliderData.euler);
                 colliderParent.transform.localScale = colliderData.scale;
-                isCustom = false;
+                isCustom = -100;
                 setScriptActive(true);
             }
             catch (InvalidEnumArgumentException)
@@ -298,12 +301,11 @@ namespace ValheimVRMod.Scripts
                 try
                 {
                     WeaponColData colliderData = WeaponUtils.CreateNewCollision(item);
-                    colliderParent.transform.parent = null;
+                    colliderParent.transform.SetParent(null);
                     colliderParent.transform.localScale = colliderData.scale;
                     colliderParent.transform.SetParent(obj, true);
-                    colliderParent.transform.LookAt(colliderParent.transform.position + LocalWeaponWield.weaponForward, VRPlayer.dominantHandRayDirection);
-                    colliderParent.transform.position = VRPlayer.dominantHand.transform.position + (LocalWeaponWield.weaponForward * item.m_shared.m_attack.m_attackRange * 0.25f);
-                    isCustom = true;
+                    UpdateCustomHitBox();
+                    isCustom = 0;
                     setScriptActive(true);
                 }
                 catch (InvalidEnumArgumentException)
@@ -314,6 +316,11 @@ namespace ValheimVRMod.Scripts
             }
         }
 
+        private void UpdateCustomHitBox()
+        {
+            colliderParent.transform.LookAt(colliderParent.transform.position + LocalWeaponWield.weaponForward, VRPlayer.dominantHandRayDirection);
+            colliderParent.transform.position = VRPlayer.dominantHand.transform.position + (LocalWeaponWield.weaponForward * item.m_shared.m_attack.m_attackRange * 0.25f);
+        }
         private void Update()
         {
 

--- a/ValheimVRMod/Scripts/WeaponWield.cs
+++ b/ValheimVRMod/Scripts/WeaponWield.cs
@@ -56,10 +56,15 @@ namespace ValheimVRMod.Scripts
                 {
                     Vector3 handleAllowanceBehindGrip =
                         WeaponUtils.EstimateHandleAllowanceBehindGrip(weaponMeshFilter, handPosition: transform.parent.position);
-                    EstimatedWeaponLocalPointingDirections.Add(
-                        itemName,
-                        estimatedLocalWeaponPointingDir =
-                            transform.InverseTransformVector(-handleAllowanceBehindGrip).normalized);
+
+                    estimatedLocalWeaponPointingDir = transform.InverseTransformVector(-handleAllowanceBehindGrip);
+                    if(estimatedLocalWeaponPointingDir.z < 0)
+                    {
+                        estimatedLocalWeaponPointingDir = (Quaternion.AngleAxis(180, Vector3.right) * estimatedLocalWeaponPointingDir);
+                    }
+                    estimatedLocalWeaponPointingDir.Normalize();
+
+                    EstimatedWeaponLocalPointingDirections.Add(itemName, estimatedLocalWeaponPointingDir);
                     DistancesBehindGripAndRearEnd.Add(
                         itemName,
                         distanceBetweenGripAndRearEnd = handleAllowanceBehindGrip.magnitude);

--- a/ValheimVRMod/Utilities/WeaponUtils.cs
+++ b/ValheimVRMod/Utilities/WeaponUtils.cs
@@ -325,9 +325,22 @@ namespace ValheimVRMod.Utilities
             if (colliders.ContainsKey(name)) {
                 return colliders[name];
             }
-            if (item != null && compatibilityColliders.ContainsKey(EquipScript.getEquippedItem(item)))
+            //Supposedly works for pickaxe, but some pickaxe still isnt accurate
+            //if (item != null && compatibilityColliders.ContainsKey(EquipScript.getEquippedItem(item)))
+            //{
+            //    return compatibilityColliders[EquipScript.getEquippedItem(item)];
+            //}
+            throw new InvalidEnumArgumentException();
+        }
+        public static WeaponColData CreateNewCollision(ItemDrop.ItemData item)
+        {
+            if(item != null)
             {
-                return compatibilityColliders[EquipScript.getEquippedItem(item)];
+                return WeaponColData.create(
+                    0, 2.158f, 0,
+                    0, 0, 0,
+                    0.05382534f, 0.1101757f, item.m_shared.m_attack.m_attackRange * 0.65f
+                );
             }
             throw new InvalidEnumArgumentException();
         }


### PR DESCRIPTION
- Add custom melee weapon collider based on weapon range and direction (which is based on button secondary attack)

Current bugs : 
- ~~Still need to unequip and equip the same weapon again 2 times to make it accurate~~ 
  (fixed but with a bit performance drop by updating for few frame at start)
- ~~some weapon direction is upside down (which also affect button secondary attack)~~ 
  (fixed but some weapon still unaligned)
- some weapon scaled the mesh weirdly (making the hitbox somehow thin but very long)


tested with mod : 
- https://valheim.thunderstore.io/package/Therzie/Warfare/
- https://valheim.thunderstore.io/package/MidnightMods/ValheimArmory/