### PR TITLE
Do not consider the hand to be free when holding dual-wielding weapon…

### DIFF
--- a/ValheimVRMod/Scripts/HandGesture.cs
+++ b/ValheimVRMod/Scripts/HandGesture.cs
@@ -56,7 +56,11 @@ namespace ValheimVRMod.Scripts {
             {
                 return true;
             }
-            
+            else if (FistCollision.hasDualWieldingWeaponEquipped())
+            {
+                return false;
+            }
+
             if (BowLocalManager.instance != null && BowLocalManager.instance.isHoldingArrow()) {
                 return false;
             }


### PR DESCRIPTION
…s except claws

Fixes the bug that non-dominant hand attack using dual weapons always require holding grip