### PR TITLE
Postpone Harmony patching to after VR initialization so that VR/flats…

### DIFF
--- a/ValheimVRMod/ValheimVRMod.cs
+++ b/ValheimVRMod/ValheimVRMod.cs
@@ -64,14 +64,6 @@ namespace ValheimVRMod
 
         void StartValheimVR()
         {
-            HarmonyPatcher.DoPatching();
-
-            if (!VRAssetManager.Initialize())
-            {
-                LogError("Problem initializing VR Assets");
-                return;
-            }
-
             bool vrInitialized = false;
             if (!VHVRConfig.NonVrPlayer())
             {
@@ -81,6 +73,14 @@ namespace ValheimVRMod
                     LogError("Could not initialize VR.");
                     failedToInitializeVR = true;
                 }
+            }
+
+            HarmonyPatcher.DoPatching();
+
+            if (!VRAssetManager.Initialize())
+            {
+                LogError("Problem initializing VR Assets");
+                return;
             }
 
             if (!vrInitialized)


### PR DESCRIPTION
…creen-specific patches can be chosen correctly

This will ensure that the correct patches are used even if the game is falling back to flatscreen mode due to VR initialization failure.

Note that VRAssertManager initialization must be done after the patching, so we need to move it along the patching too.