### PR TITLE
Reduce the max number of VR initialization tries to 3

### DIFF
--- a/ValheimVRMod/Utilities/VHVRConfig.cs
+++ b/ValheimVRMod/Utilities/VHVRConfig.cs
@@ -235,7 +235,7 @@ namespace ValheimVRMod.Utilities
                 "This setting, if true, will also force UseOverlayGui to be false as this setting Overlay GUI is not compatible with VR laser pointer inputs.");
             maxVRInitializationTries = config.Bind("Immutable",
                 "MaxVRInitializationTries",
-                1024,
+                3,
                 new ConfigDescription("The maximum number of attempts at initialization VR before falling back to flatscreen mode",
                 new AcceptableValueRange<int>(0, 1024)));
 

--- a/ValheimVRMod/Utilities/VHVRConfig.cs
+++ b/ValheimVRMod/Utilities/VHVRConfig.cs
@@ -235,9 +235,9 @@ namespace ValheimVRMod.Utilities
                 "This setting, if true, will also force UseOverlayGui to be false as this setting Overlay GUI is not compatible with VR laser pointer inputs.");
             maxVRInitializationTries = config.Bind("Immutable",
                 "MaxVRInitializationTries",
-                3,
+                6,
                 new ConfigDescription("The maximum number of attempts at initialization VR before falling back to flatscreen mode",
-                new AcceptableValueRange<int>(0, 1024)));
+                new AcceptableValueRange<int>(1, 1024)));
 
             useOverlayGui = createImmutableSettingWithOverride("Immutable",
                 "UseOverlayGui",

--- a/ValheimVRMod/Utilities/VHVRConfig.cs
+++ b/ValheimVRMod/Utilities/VHVRConfig.cs
@@ -235,7 +235,7 @@ namespace ValheimVRMod.Utilities
                 "This setting, if true, will also force UseOverlayGui to be false as this setting Overlay GUI is not compatible with VR laser pointer inputs.");
             maxVRInitializationTries = config.Bind("Immutable",
                 "MaxVRInitializationTries",
-                6,
+                3,
                 new ConfigDescription("The maximum number of attempts at initialization VR before falling back to flatscreen mode",
                 new AcceptableValueRange<int>(1, 1024)));
 


### PR DESCRIPTION
Each try can take a few seconds. Reducing the maximum number of tries can falling back to flatscreen mode actually happen practically.