### PR TITLE
Add Movement type of secondary attack using button secondary attack system

### DIFF
--- a/ValheimVRMod/Patches/CollisionPatches.cs
+++ b/ValheimVRMod/Patches/CollisionPatches.cs
@@ -85,7 +85,7 @@ namespace ValheimVRMod.Patches {
                 ___m_attackMaskTerrain = LayerMask.GetMask("Default", "static_solid", "Default_small", "piece", "piece_nonsolid", "terrain", nameof (character), "character_net", "character_ghost", "hitbox", "character_noenv", "vehicle");
             }
             
-            if (!AttackTargetMeshCooldown.staminaDrained && !ButtonSecondaryAttackManager.isStaminaDrained) {
+            if (!(AttackTargetMeshCooldown.staminaDrained || ButtonSecondaryAttackManager.isStaminaDrained)) {
                 float staminaUsage = (float) __instance.GetAttackStamina();
                 if (staminaUsage > 0.0f && !character.HaveStamina(staminaUsage + 0.1f)) {
                     // FIXME: Mystlands probably changed this from StaminaBarNoStaminaFlash

--- a/ValheimVRMod/Patches/CollisionPatches.cs
+++ b/ValheimVRMod/Patches/CollisionPatches.cs
@@ -85,7 +85,7 @@ namespace ValheimVRMod.Patches {
                 ___m_attackMaskTerrain = LayerMask.GetMask("Default", "static_solid", "Default_small", "piece", "piece_nonsolid", "terrain", nameof (character), "character_net", "character_ghost", "hitbox", "character_noenv", "vehicle");
             }
             
-            if (!AttackTargetMeshCooldown.staminaDrained) {
+            if (!AttackTargetMeshCooldown.staminaDrained && !ButtonSecondaryAttackManager.isStaminaDrained) {
                 float staminaUsage = (float) __instance.GetAttackStamina();
                 if (staminaUsage > 0.0f && !character.HaveStamina(staminaUsage + 0.1f)) {
                     // FIXME: Mystlands probably changed this from StaminaBarNoStaminaFlash
@@ -97,11 +97,12 @@ namespace ValheimVRMod.Patches {
                     ___m_attackOffset = attackOffset;
                     return false;
                 }
-            
+
                 character.UseStamina(staminaUsage);
                 AttackTargetMeshCooldown.staminaDrained = true;
             }
 
+            ButtonSecondaryAttackManager.isStaminaDrained = false;
             Collider col = StaticObjects.lastHitCollider;
             Vector3 pos = StaticObjects.lastHitPoint;
             Vector3 dir = StaticObjects.lastHitDir;

--- a/ValheimVRMod/Scripts/ButtonSecondaryAttackManager.cs
+++ b/ValheimVRMod/Scripts/ButtonSecondaryAttackManager.cs
@@ -48,6 +48,7 @@ namespace ValheimVRMod.Scripts
         private bool isMovementSecondaryAttack;
         private float movementCooldown;
         private bool isMovementSecondaryAttackHold;
+        public static bool isStaminaDrained;
 
         private void Awake()
         {
@@ -109,6 +110,7 @@ namespace ValheimVRMod.Scripts
             }
             isSecondaryAttackStarted = false;
             isSecondaryAttackTriggered = true;
+            isStaminaDrained = false;
         }
 
         public void Initialize(Transform obj, string name, bool isRightHand)
@@ -127,6 +129,7 @@ namespace ValheimVRMod.Scripts
             attack = item.m_shared.m_attack.Clone();
             secondaryAttack = item.m_shared.m_secondaryAttack.Clone();
             isMovementSecondaryAttackHold = false;
+            isStaminaDrained = false;
 
             float damage = 0;
             if (item.m_shared.m_damages.m_slash > damage)
@@ -276,6 +279,10 @@ namespace ValheimVRMod.Scripts
                     {
                         isMovementSecondaryAttackHold = true;
                     }
+                    else
+                    {
+                        isStaminaDrained = false;
+                    }
 
                     isSecondaryAttackStarted = true;
                     hitDir = Vector3.zero;
@@ -420,10 +427,11 @@ namespace ValheimVRMod.Scripts
                         direction.y = 0;
                         var clampedRange = Mathf.Clamp(range, 0.3f, 1);
                         Player.m_localPlayer.ForceJump(direction.normalized * 10 * clampedRange + (Vector3.up * 8), true);
-                        Player.m_localPlayer.UseStamina(getStaminaSecondaryAtttackUsage()/3);
+                        Player.m_localPlayer.UseStamina(getStaminaSecondaryAtttackUsage());
 
                         var time = WeaponUtils.GetAttackDuration(secondaryAttack);
                         movementCooldown = time;
+                        isStaminaDrained = true;
                     }
                     else
                     {

--- a/ValheimVRMod/Scripts/ButtonSecondaryAttackManager.cs
+++ b/ValheimVRMod/Scripts/ButtonSecondaryAttackManager.cs
@@ -237,7 +237,7 @@ namespace ValheimVRMod.Scripts
             var localHandPos = VRPlayer.dominantHand.transform.position - Player.m_localPlayer.transform.position;
             var posHeight = Player.m_localPlayer.transform.InverseTransformPoint(VRPlayer.dominantHand.transform.position + localWeaponForward);
 
-            if (isMovementSecondaryAttack && movementCooldown <= 0 && !isMovementSecondaryAttackHold)
+            if (isMovementSecondaryAttack && !(movementCooldown >= 0 || isMovementSecondaryAttackHold))
             {
                 localWeaponForward = Vector3.zero;
             }
@@ -272,6 +272,11 @@ namespace ValheimVRMod.Scripts
                     slashTrail.emitting = true;
                     slashTrail.Clear();
 
+                    if (isMovementSecondaryAttack && movementCooldown >= 0 && !isMovementSecondaryAttackHold) 
+                    {
+                        isMovementSecondaryAttackHold = true;
+                    }
+
                     isSecondaryAttackStarted = true;
                     hitDir = Vector3.zero;
                 }
@@ -279,7 +284,6 @@ namespace ValheimVRMod.Scripts
                 if (firstPos != Vector3.zero && !mainHandTrigger)
                 {
                     lastPos = localHandPos + localWeaponForward;
-                    isMovementSecondaryAttackHold = false;
                 }
             }
             
@@ -394,7 +398,7 @@ namespace ValheimVRMod.Scripts
                 pointList = new List<Vector3>();
 
                 //Secondary attack raycast check
-                if (isMovementSecondaryAttack && movementCooldown <=0)
+                if (isMovementSecondaryAttack && movementCooldown <=0 && !isMovementSecondaryAttackHold)
                 {
                     var firstTrail = slashTrail.GetPosition(0);
                     var halfTrail = slashTrail.GetPosition((int)((slashTrail.positionCount - 1) * 0.5f));
@@ -404,6 +408,7 @@ namespace ValheimVRMod.Scripts
 
                     var range = (Vector3.Distance(firstTrail, halfTrail) + Vector3.Distance(halfTrail, endTrail));
                     //LogUtils.LogDebug("range : " + range);
+                    isMovementSecondaryAttackHold = false;
                     if (range < 0.2f)
                     {
                         ResetSecondaryAttack();
@@ -419,7 +424,6 @@ namespace ValheimVRMod.Scripts
 
                         var time = WeaponUtils.GetAttackDuration(secondaryAttack);
                         movementCooldown = time;
-                        isMovementSecondaryAttackHold = true;
                     }
                     else
                     {
@@ -466,7 +470,8 @@ namespace ValheimVRMod.Scripts
                     }
                     slashLine.SetPositions(pointList.ToArray());
                     slashLine.positionCount = 5;
-
+                    isMovementSecondaryAttackHold = false;
+                    movementCooldown = -1;
                     if ((Vector3.Distance(firstTrail, halfTrail) + Vector3.Distance(halfTrail, endTrail)) < secondaryAttack.m_attackRange * 0.5f)
                     {
                         ResetSecondaryAttack();

--- a/ValheimVRMod/Scripts/ButtonSecondaryAttackManager.cs
+++ b/ValheimVRMod/Scripts/ButtonSecondaryAttackManager.cs
@@ -432,7 +432,7 @@ namespace ValheimVRMod.Scripts
                         Player.m_localPlayer.ForceJump(direction.normalized * 10 * clampedRange + (Vector3.up * 8), true);
                         Player.m_localPlayer.UseStamina(getStaminaSecondaryAtttackUsage());
 
-                        var time = WeaponUtils.GetAttackDuration(secondaryAttack);
+                        var time = GetAttackDurationWithMovement(secondaryAttack);
                         movementCooldown = time;
                         isStaminaDrained = true;
                     }
@@ -502,7 +502,7 @@ namespace ValheimVRMod.Scripts
                     RaycastSecondaryAttack(tempSecondaryHitList);
                 }
 
-                var hitTime = WeaponUtils.GetAttackDuration(secondaryAttack);
+                var hitTime = GetAttackDurationWithMovement(secondaryAttack);
                 secondaryAttackTimer = Mathf.Min(hitTime / 2, 0.1f);
                 secondaryAttackTimerFull = -hitTime + secondaryAttackTimer;
 
@@ -585,7 +585,7 @@ namespace ValheimVRMod.Scripts
 
         private void ResetSecondaryAttack()
         {
-            var hitTime = WeaponUtils.GetAttackDuration(secondaryAttack);
+            var hitTime = GetAttackDurationWithMovement(secondaryAttack);
             secondaryAttackTimer = Mathf.Min(hitTime / 2, 0.3f);
             secondaryAttackTimerFull = -hitTime + secondaryAttackTimer;
             firstPos = Vector3.zero;
@@ -593,6 +593,15 @@ namespace ValheimVRMod.Scripts
             isSecondaryAttackStarted = false;
             slashTrail.emitting = false;
             lastpointList = new List<Vector3>();
+        }
+
+        private float GetAttackDurationWithMovement(Attack secondaryAttack)
+        {
+            if (isMovementSecondaryAttack && isMovementSecondaryAttackHold)
+            {
+                return 0.2f;
+            }
+            return WeaponUtils.GetAttackDuration(secondaryAttack);
         }
         private void RaycastSecondaryAttack(RaycastHit[] raycastList)
         {

--- a/ValheimVRMod/Scripts/ButtonSecondaryAttackManager.cs
+++ b/ValheimVRMod/Scripts/ButtonSecondaryAttackManager.cs
@@ -195,7 +195,10 @@ namespace ValheimVRMod.Scripts
                 isSecondaryAvailable = false;
             }
             
-            if (secondaryAttack.m_attackAnimation == "knife_secondary" || secondaryAttack.m_attackAnimation == "dual_knives_secondary")
+            if (VHVRConfig.MovementSecondaryAttack()
+                && (secondaryAttack.m_attackAnimation == "knife_secondary" 
+                || secondaryAttack.m_attackAnimation == "dual_knives_secondary"
+                || secondaryAttack.m_attackAnimation == "dualaxes_secondary"))
             {
                 slashTrail.time = 1f;
                 isMovementSecondaryAttack = true;
@@ -504,7 +507,7 @@ namespace ValheimVRMod.Scripts
                 secondaryAttackTimerFull = -hitTime + secondaryAttackTimer;
 
                 //Secondary attack check target outlines and terrain hit
-                if (secondaryHitList.Count >= 1 && Player.m_localPlayer.HaveStamina(getStaminaSecondaryAtttackUsage() + 0.1f))
+                if (secondaryHitList.Count >= 1 && (Player.m_localPlayer.HaveStamina(getStaminaSecondaryAtttackUsage() + 0.1f)||isStaminaDrained))
                 {
                     var isTerrain = item.m_shared.m_spawnOnHitTerrain ? true : false;
                     foreach (var hit in secondaryHitList)

--- a/ValheimVRMod/Utilities/VHVRConfig.cs
+++ b/ValheimVRMod/Utilities/VHVRConfig.cs
@@ -150,6 +150,7 @@ namespace ValheimVRMod.Utilities
         private static ConfigEntry<string> crossbowSaggitalRotationSource;
         private static ConfigEntry<bool> crossbowManualReload;
         private static ConfigEntry<string> blockingType;
+        private static ConfigEntry<bool> movementSecondaryAttack;
 
 #if DEBUG
         private static ConfigEntry<float> DebugPosX;
@@ -864,7 +865,10 @@ namespace ValheimVRMod.Utilities
                                         "Grab button - Block by aiming and pressing grab button, parry by timing the grab button. " +
                                         "Realistic - Block precisely where the enemy hits, swing while blocking to parry",
                                         new AcceptableValueList<string>(new string[] { "Gesture", "GrabButton", "Realistic" })));
-
+            movementSecondaryAttack = config.Bind("Motion Control",
+                                                    "KnifeMovementSecondaryAttack",
+                                                    false,
+                                                    "When enabled, Weapon that have movement secondary attack (Knife) button secondary attack will have 2 step, first trigger-release will make you leap, the second one works like usual button secondary attack. Re-equip after changing setting to update");
 
             advancedBuildMode = config.Bind("Motion Control",
                                                    "AdvancedBuildMode",
@@ -1424,6 +1428,11 @@ namespace ValheimVRMod.Utilities
         public static string BlockingType()
         {
             return blockingType.Value;
+        }
+
+        public static bool MovementSecondaryAttack()
+        {
+            return movementSecondaryAttack.Value;
         }
 
         public static bool UseLegacyHud()


### PR DESCRIPTION
add movement based system for secondary attack (like knife)

currently you can use it by holding grab + trigger while hand is downward and then drag it forward + upward like jumping to do a jump

and then while jumping, you can hold grab + trigger again to trigger the usual button secondary attack


Currently only can be used for knife, but it should work with dual knives and dual axes later