### PR TITLE
Add Cinematic Third Person follow cam

### DIFF
--- a/ValheimVRMod/Utilities/ThirdPersonCameraUpdater.cs
+++ b/ValheimVRMod/Utilities/ThirdPersonCameraUpdater.cs
@@ -18,6 +18,7 @@ namespace ValheimVRMod.Utilities
         private Vector3 velocity;
         private MeshRenderer cameraDot;
         private float cameraSpeed;
+        private float targetCameraSpeed;
 
         private Vector3 targetCurrentPosition;
         private Vector3 targetVelocity;
@@ -43,7 +44,7 @@ namespace ValheimVRMod.Utilities
                 var panel = VRCore.UI.VRGUI.getUiPanel();
                 if (panel)
                 {
-                    transform.position = panel.transform.position - panel.transform.forward * 2;
+                    transform.position = panel.transform.position - panel.transform.forward * 1.5f;
                     transform.LookAt(panel.transform.position);
                 }
                 else
@@ -68,6 +69,7 @@ namespace ValheimVRMod.Utilities
             Vector3 viewTarget = targetPosition;
             var uiPanel = VRCore.UI.VRGUI.getUiPanel();
             cameraSpeed = 0.15f;
+            targetCameraSpeed = 0.2f;
             if (PlayerCustomizaton.IsBarberGuiVisible())
             {
                 viewPoint = vrCamera.transform.position;
@@ -75,12 +77,12 @@ namespace ValheimVRMod.Utilities
             }
             else if (VHVRConfig.UseFollowCameraOnFlatscreen())
             {
-                //When sleeping
-                if (Player.m_localPlayer.IsSleeping())
+                //When sleeping and teleporting
+                if (Player.m_localPlayer.IsSleeping()||Player.m_localPlayer.IsTeleporting())
                 {
                     viewTarget = uiPanel.transform.position;
 
-                    viewPoint = uiPanel.transform.position - uiPanel.transform.forward * 2;
+                    viewPoint = uiPanel.transform.position - uiPanel.transform.forward * 1.5f;
                 }
                 //When opening UI
                 else if (VRPlayer.IsClickableGuiOpen)
@@ -93,6 +95,7 @@ namespace ValheimVRMod.Utilities
                     - vrCamera.transform.forward * 0.3f;
 
                     cameraSpeed = 0.01f;
+                    targetCameraSpeed = 0.01f;
                 }
                 // When drawing bow / throwing 
                 else if (Player.m_localPlayer.IsDrawingBow() || ThrowableManager.isAiming)
@@ -145,7 +148,7 @@ namespace ValheimVRMod.Utilities
                     viewTarget = vrCamera.transform.position + vrCamera.transform.forward * 1.5f;
 
                     viewPoint = targetPosition +
-                      Vector3.up * 2
+                      Vector3.up * 3
                     - vrCamera.transform.forward * 3.5f;
                 }
             }
@@ -159,7 +162,7 @@ namespace ValheimVRMod.Utilities
             ClampViewPointToAvoidObstruction(targetPosition, maxDistance: 3, ref viewPoint);
 
             transform.position = Vector3.SmoothDamp(transform.position, viewPoint, ref velocity, cameraSpeed);
-            targetCurrentPosition = Vector3.SmoothDamp(targetCurrentPosition, viewTarget, ref targetVelocity, cameraSpeed);
+            targetCurrentPosition = Vector3.SmoothDamp(targetCurrentPosition, viewTarget, ref targetVelocity, targetCameraSpeed);
             transform.LookAt(targetCurrentPosition);
 
             UpdateCameraDot();

--- a/ValheimVRMod/Utilities/ThirdPersonCameraUpdater.cs
+++ b/ValheimVRMod/Utilities/ThirdPersonCameraUpdater.cs
@@ -1,5 +1,7 @@
 using UnityEngine;
+using ValheimVRMod.Scripts;
 using ValheimVRMod.VRCore;
+using Valve.VR;
 
 namespace ValheimVRMod.Utilities
 {
@@ -15,6 +17,10 @@ namespace ValheimVRMod.Utilities
         private Camera vrCamera;
         private Vector3 velocity;
         private MeshRenderer cameraDot;
+        private float cameraSpeed;
+
+        private Vector3 targetCurrentPosition;
+        private Vector3 targetVelocity;
 
         void FixedUpdate()
         {
@@ -34,7 +40,17 @@ namespace ValheimVRMod.Utilities
 
             if (!Player.m_localPlayer)
             {
-                transform.SetPositionAndRotation(vrCamera.transform.position, vrCamera.transform.rotation);
+                var panel = VRCore.UI.VRGUI.getUiPanel();
+                if (panel)
+                {
+                    transform.position = panel.transform.position - panel.transform.forward * 2;
+                    transform.LookAt(panel.transform.position);
+                }
+                else
+                {
+                    transform.SetPositionAndRotation(vrCamera.transform.position, vrCamera.transform.rotation);
+                }
+                
                 velocity = Vector3.zero;
                 return;
             }
@@ -49,6 +65,9 @@ namespace ValheimVRMod.Utilities
             }
 
             Vector3 viewPoint;
+            Vector3 viewTarget = targetPosition;
+            var uiPanel = VRCore.UI.VRGUI.getUiPanel();
+            cameraSpeed = 0.15f;
             if (PlayerCustomizaton.IsBarberGuiVisible())
             {
                 viewPoint = vrCamera.transform.position;
@@ -56,7 +75,79 @@ namespace ValheimVRMod.Utilities
             }
             else if (VHVRConfig.UseFollowCameraOnFlatscreen())
             {
-                viewPoint = targetPosition + Vector3.up * 2 - vrCamera.transform.forward * 3.5f;
+                //When sleeping
+                if (Player.m_localPlayer.IsSleeping())
+                {
+                    viewTarget = uiPanel.transform.position;
+
+                    viewPoint = uiPanel.transform.position - uiPanel.transform.forward * 2;
+                }
+                //When opening UI
+                else if (VRPlayer.IsClickableGuiOpen)
+                {
+                    viewTarget = uiPanel.transform.position;
+
+                    viewPoint = targetPosition +
+                    -uiPanel.transform.right * 0.5f
+                    + Vector3.up * 0.3f
+                    - vrCamera.transform.forward * 0.3f;
+
+                    cameraSpeed = 0.01f;
+                }
+                // When drawing bow / throwing 
+                else if (Player.m_localPlayer.IsDrawingBow() || ThrowableManager.isAiming)
+                {
+
+                    viewTarget = vrCamera.transform.position 
+                        - Vector3.up * 1f 
+                        + vrCamera.transform.forward * 6f;
+
+                    viewPoint = targetPosition +
+                    -Player.m_localPlayer.transform.right * 0.7f
+                    + Vector3.up * 0.3f
+                    - vrCamera.transform.forward * 1.5f;
+
+                    cameraSpeed = 0.1f;
+                }
+                // When using Ranged Weapon
+                else if (BowLocalManager.instance || CrossbowMorphManager.instance)
+                {
+                    viewTarget = vrCamera.transform.position
+                        - Vector3.up * 1f 
+                        + vrCamera.transform.forward * 3f;
+
+                    viewPoint = targetPosition +
+                    -Player.m_localPlayer.transform.right * 1f
+                    + Vector3.up * 0.3f
+                    - vrCamera.transform.forward * 2f;
+
+                    cameraSpeed = 0.1f;
+                }
+                //When holding both grab, usually happens when trying to hit monster & two-handing
+                else if (LocalWeaponWield.isCurrentlyTwoHanded()||
+                    (!Player.m_localPlayer.InPlaceMode() 
+                    && SteamVR_Actions.valheim_Grab.GetState(SteamVR_Input_Sources.LeftHand) 
+                    && SteamVR_Actions.valheim_Grab.GetState(SteamVR_Input_Sources.RightHand)))
+                {
+                    viewTarget = vrCamera.transform.position
+                        - Vector3.up * 1f
+                        + vrCamera.transform.forward * 3f;
+
+                    viewPoint = targetPosition +
+                      Player.m_localPlayer.transform.right * 3f
+                    + Vector3.up * 2f
+                    - vrCamera.transform.forward * 3f;
+
+                    cameraSpeed = 0.1f;
+                }
+                else
+                {
+                    viewTarget = vrCamera.transform.position + vrCamera.transform.forward * 1.5f;
+
+                    viewPoint = targetPosition +
+                      Vector3.up * 2
+                    - vrCamera.transform.forward * 3.5f;
+                }
             }
             else
             {
@@ -67,8 +158,9 @@ namespace ValheimVRMod.Utilities
 
             ClampViewPointToAvoidObstruction(targetPosition, maxDistance: 3, ref viewPoint);
 
-            transform.position = Vector3.SmoothDamp(transform.position, viewPoint, ref velocity, 0.25f);
-            transform.LookAt(targetPosition);
+            transform.position = Vector3.SmoothDamp(transform.position, viewPoint, ref velocity, cameraSpeed);
+            targetCurrentPosition = Vector3.SmoothDamp(targetCurrentPosition, viewTarget, ref targetVelocity, cameraSpeed);
+            transform.LookAt(targetCurrentPosition);
 
             UpdateCameraDot();
         }
@@ -113,6 +205,7 @@ namespace ValheimVRMod.Utilities
                 cameraDot.material = Instantiate(VRAssetManager.GetAsset<Material>("Unlit"));
                 cameraDot.material.color = Color.red;
                 cameraDot.gameObject.layer = LayerUtils.getUiPanelLayer();
+                Destroy(cameraDot.GetComponent<Collider>());
             }
 
             cameraDot.transform.localScale =

--- a/ValheimVRMod/Utilities/ThirdPersonCameraUpdater.cs
+++ b/ValheimVRMod/Utilities/ThirdPersonCameraUpdater.cs
@@ -77,79 +77,63 @@ namespace ValheimVRMod.Utilities
             }
             else if (VHVRConfig.UseFollowCameraOnFlatscreen())
             {
-                //When sleeping and teleporting
-                if (Player.m_localPlayer.IsSleeping()||Player.m_localPlayer.IsTeleporting())
+                if (Player.m_localPlayer.IsSleeping() || Player.m_localPlayer.IsTeleporting())
                 {
                     viewTarget = uiPanel.transform.position;
-
                     viewPoint = uiPanel.transform.position - uiPanel.transform.forward * 1.5f;
                 }
-                //When opening UI
                 else if (VRPlayer.IsClickableGuiOpen)
                 {
                     viewTarget = uiPanel.transform.position;
-
-                    viewPoint = targetPosition +
-                    -uiPanel.transform.right * 0.5f
-                    + Vector3.up * 0.3f
-                    - vrCamera.transform.forward * 0.3f;
-
+                    viewPoint = targetPosition - uiPanel.transform.right * 0.5f + Vector3.up * 0.3f - vrCamera.transform.forward * 0.3f;
                     cameraSpeed = 0.01f;
                     targetCameraSpeed = 0.01f;
                 }
-                // When drawing bow / throwing 
-                else if (Player.m_localPlayer.IsDrawingBow() || ThrowableManager.isAiming)
+                else if (Player.m_localPlayer.IsDrawingBow() || ThrowableManager.isAiming || CrossbowManager.isAiming)
                 {
-
-                    viewTarget = vrCamera.transform.position 
-                        - Vector3.up * 1f 
-                        + vrCamera.transform.forward * 6f;
-
-                    viewPoint = targetPosition +
-                    -Player.m_localPlayer.transform.right * 0.7f
-                    + Vector3.up * 0.3f
-                    - vrCamera.transform.forward * 1.5f;
-
+                    viewTarget = vrCamera.transform.position - Vector3.up + vrCamera.transform.forward * 6;
+                    viewPoint =
+                        targetPosition + Vector3.up * 0.3f - vrCamera.transform.forward * 1.5f +
+                        Player.m_localPlayer.transform.right * (VHVRConfig.LeftHanded() ? 0.7f : -0.7f);
                     cameraSpeed = 0.1f;
                 }
-                // When using Ranged Weapon
                 else if (BowLocalManager.instance || CrossbowMorphManager.instance)
                 {
-                    viewTarget = vrCamera.transform.position
-                        - Vector3.up * 1f 
-                        + vrCamera.transform.forward * 3f;
+                    viewTarget = vrCamera.transform.position - Vector3.up + vrCamera.transform.forward * 3;
 
-                    viewPoint = targetPosition +
-                    -Player.m_localPlayer.transform.right * 1f
-                    + Vector3.up * 0.3f
-                    - vrCamera.transform.forward * 2f;
+                    viewPoint =
+                        targetPosition - Player.m_localPlayer.transform.right + Vector3.up * 0.3f - vrCamera.transform.forward * 2f;
 
                     cameraSpeed = 0.1f;
                 }
-                //When holding both grab, usually happens when trying to hit monster & two-handing
-                else if (LocalWeaponWield.isCurrentlyTwoHanded()||
-                    (!Player.m_localPlayer.InPlaceMode() 
-                    && SteamVR_Actions.valheim_Grab.GetState(SteamVR_Input_Sources.LeftHand) 
+                // When holding both grab, usually happens when trying to hit monster & two-handing
+                else if (LocalWeaponWield.isCurrentlyTwoHanded() ||
+                    (!Player.m_localPlayer.InPlaceMode()
+                    && SteamVR_Actions.valheim_Grab.GetState(SteamVR_Input_Sources.LeftHand)
                     && SteamVR_Actions.valheim_Grab.GetState(SteamVR_Input_Sources.RightHand)))
                 {
-                    viewTarget = vrCamera.transform.position
-                        - Vector3.up * 1f
-                        + vrCamera.transform.forward * 3f;
+                    var lateralOffset = Player.m_localPlayer.transform.right * 3;
+                    switch (LocalWeaponWield.LocalPlayerTwoHandedState)
+                    {
+                        case WeaponWield.TwoHandedState.LeftHandBehind:
+                            lateralOffset *= -1;
+                            break;
+                        case WeaponWield.TwoHandedState.SingleHanded:
+                            if (VHVRConfig.LeftHanded())
+                            {
+                                lateralOffset *= -1;
+                            }
+                            break;
+                    }
 
-                    viewPoint = targetPosition +
-                      Player.m_localPlayer.transform.right * 3f
-                    + Vector3.up * 2f
-                    - vrCamera.transform.forward * 3f;
-
+                    viewTarget = vrCamera.transform.position - Vector3.up + vrCamera.transform.forward * 3;
+                    viewPoint = targetPosition + lateralOffset + Vector3.up * 2f - vrCamera.transform.forward * 3f;
                     cameraSpeed = 0.1f;
                 }
                 else
                 {
                     viewTarget = vrCamera.transform.position + vrCamera.transform.forward * 1.5f;
-
-                    viewPoint = targetPosition +
-                      Vector3.up * 3
-                    - vrCamera.transform.forward * 3.5f;
+                    viewPoint = targetPosition + Vector3.up * 3 - vrCamera.transform.forward * 3.5f;
                 }
             }
             else

--- a/ValheimVRMod/VRCore/UI/VRGUI.cs
+++ b/ValheimVRMod/VRCore/UI/VRGUI.cs
@@ -66,7 +66,7 @@ namespace ValheimVRMod.VRCore.UI
         private Camera _uiPanelCamera;
         private Camera _guiCamera;
         private Canvas _guiCanvas;
-        private GameObject _uiPanel;
+        private static GameObject _uiPanel;
         private GameObject _uiPanelTransformLocker;
         private RenderTexture _guiTexture;
         private RenderTexture _overlayTexture;
@@ -662,6 +662,11 @@ namespace ValheimVRMod.VRCore.UI
             _guiCamera.farClipPlane = 5f;
             _guiCamera.nearClipPlane = 0.1f;
             _guiCamera.enabled = true;
+        }
+
+        public static GameObject getUiPanel()
+        {
+            return _uiPanel;
         }
 
         class VRGUI_InputModule : StandaloneInputModule

--- a/ValheimVRMod/VRCore/VRPlayer.cs
+++ b/ValheimVRMod/VRCore/VRPlayer.cs
@@ -728,6 +728,7 @@ namespace ValheimVRMod.VRCore
             _thirdPersonCamera.depth = 4;
             // Borrow the character trigger layer to render headgears which should be hidden for the VR camera.
             _thirdPersonCamera.cullingMask |= (1 << LayerUtils.CHARARCTER_TRIGGER);
+            _thirdPersonCamera.cullingMask = ~0;
             _thirdPersonCamera.transform.position = vrCam.transform.position;
             _thirdPersonCamera.stereoTargetEye = StereoTargetEyeMask.None;
             _thirdPersonCamera.gameObject.AddComponent<ThirdPersonCameraUpdater>();

--- a/ValheimVRMod/VRCore/VRPlayer.cs
+++ b/ValheimVRMod/VRCore/VRPlayer.cs
@@ -728,7 +728,8 @@ namespace ValheimVRMod.VRCore
             _thirdPersonCamera.depth = 4;
             // Borrow the character trigger layer to render headgears which should be hidden for the VR camera.
             _thirdPersonCamera.cullingMask |= (1 << LayerUtils.CHARARCTER_TRIGGER);
-            _thirdPersonCamera.cullingMask = ~0;
+            _thirdPersonCamera.cullingMask |= (1 << LayerUtils.getUiPanelLayer());
+            _thirdPersonCamera.cullingMask |= (1 << LayerUtils.getWorldspaceUiLayer());
             _thirdPersonCamera.transform.position = vrCam.transform.position;
             _thirdPersonCamera.stereoTargetEye = StereoTargetEyeMask.None;
             _thirdPersonCamera.gameObject.AddComponent<ThirdPersonCameraUpdater>();


### PR DESCRIPTION
basically just add extra camera position on some condition :
- on start screen
- when opening UI (might need option to make ui in front of everything)
- when using ranged weapon
- when drawing/ aiming throwing weapon
- when both grab button is hold (which usually getting ready to hit anything/two-handing weapon)

some fix :
- removing camera dot collider since it can collide with player

todo :
- adding option toggle for camera stuff
- UI in front of anything (off / on opening ui only / always option)
- ~~use proper layer than showing all layer~~
- probably add sailing/riding camera option too