### PR TITLE
Add option for more/less quick switch bar quantity

### DIFF
--- a/ValheimVRMod/Scripts/QuickAbstract.cs
+++ b/ValheimVRMod/Scripts/QuickAbstract.cs
@@ -320,7 +320,7 @@ namespace ValheimVRMod.Scripts
                     extraElements[i].gameObject.SetActive(false);
                     continue;
                 }
-                var center = Mathf.Min(extraElementCount,4);
+                var center = Mathf.Min(extraElementCount, 4);
                 var row = 0f;
                 var column = i;
                 if (i >= 4)

--- a/ValheimVRMod/Scripts/QuickAbstract.cs
+++ b/ValheimVRMod/Scripts/QuickAbstract.cs
@@ -14,7 +14,7 @@ namespace ValheimVRMod.Scripts
 
         private float elementDistance = 0.1f;
         protected const int MAX_ELEMENTS = 11;
-        protected const int MAX_EXTRA_ELEMENTS = 5;
+        protected const int MAX_EXTRA_ELEMENTS = 8;
 
         private Color standard = new Color(0.2f, 0.2f, 0.2f, 0.5f);
         private Color hovered = new Color(0.5f, 0.5f, 0.5f, 0.5f);
@@ -320,9 +320,17 @@ namespace ValheimVRMod.Scripts
                     extraElements[i].gameObject.SetActive(false);
                     continue;
                 }
-                var extraOffset = (i * 0.05f) - (extraElementCount / 2 * 0.05f) + (extraElementCount % 2 == 0 ? 0.025f : 0);
-                var position = new Vector2((float)extraOffset, 0);
-
+                var center = Mathf.Min(extraElementCount,4);
+                var row = 0f;
+                var column = i;
+                if (i >= 4)
+                {
+                    row = -0.05f;
+                    center = extraElementCount - 4;
+                    column = i - 4;
+                }
+                var extraOffset = (column * 0.05f) - (center / 2 * 0.05f) + (center % 2 == 0 ? 0.025f : 0);
+                var position = new Vector2((float)extraOffset, row);
                 extraElements[i].gameObject.SetActive(true);
                 extraElements[i].transform.localPosition = position;
             }
@@ -505,10 +513,10 @@ namespace ValheimVRMod.Scripts
             {
                 return;
             }
-            for (int i = 0; i < 4; i++)
+            for (int i = 0; i < VHVRConfig.QuickBarQuantity(); i++)
             {
 
-                ItemDrop.ItemData item = inventory?.GetItemAt(i + 4, 1);
+                ItemDrop.ItemData item = inventory?.GetItemAt(i + (8- VHVRConfig.QuickBarQuantity()), 1);
 
                 if (item == null)
                 {

--- a/ValheimVRMod/Utilities/VHVRConfig.cs
+++ b/ValheimVRMod/Utilities/VHVRConfig.cs
@@ -90,6 +90,7 @@ namespace ValheimVRMod.Utilities
         private static ConfigEntry<Vector3> leftWristQuickBarPos;
         private static ConfigEntry<Quaternion> leftWristQuickBarRot;
         private static ConfigEntry<bool> quickActionOnLeftHand;
+        private static ConfigEntry<int> quickBarQuantity;
 
         // Controls Settings
         private static ConfigEntry<bool> useLookLocomotion;
@@ -597,6 +598,11 @@ namespace ValheimVRMod.Utilities
                                         "QuickActionOnLeftHand",
                                         false,
                                         "Switch hand placement of Quick Action and Quick Switch Hotbar");
+            quickBarQuantity = config.Bind("VRHUD",
+                                        "QuickBarQuantity",
+                                        4,
+                                        new ConfigDescription("Number of Quick switch bar that registered, count is from the right to left, but still sorted from left to right",
+                                                new AcceptableValueRange<int>(0, 8)));
         }
 
         private static void InitializeControlsSettings()
@@ -1585,6 +1591,15 @@ namespace ValheimVRMod.Utilities
         public static bool QuickActionOnLeftHand()
         {
             return quickActionOnLeftHand.Value;
+        }
+
+        public static int QuickBarQuantity()
+        {
+            if(quickBarQuantity.Value <0 || quickBarQuantity.Value > 8)
+            {
+                return (int)quickBarQuantity.DefaultValue;
+            }
+            return quickBarQuantity.Value;
         }
 
         public static bool LockGuiWhileMenuOpen()


### PR DESCRIPTION
in default, the quick switch have 4 in a bar, when changing to above 4, row will be split into 2
can be changed between 0 (none) to 8 (whole row of inventory)