### PR TITLE
Add more config options for VR treadmill QoL improvements

### DIFF
--- a/ValheimVRMod/Patches/ControlPatches.cs
+++ b/ValheimVRMod/Patches/ControlPatches.cs
@@ -103,10 +103,14 @@ namespace ValheimVRMod.Patches {
                     if (joystick > -0.3f && joystick < 0.3f)
                     {
                         __result = 0f;
-                        return;
                     }
+                    else
+                    {
+                        __result += joystick;
+                    }
+                    return;
                 }
-                __result = __result + VRControls.instance.GetJoyLeftStickX() + (VRPlayer.gesturedLocomotionManager?.stickOutputX ?? 0);
+                __result = __result + joystick / VHVRConfig.AutoRunThreshold() + (VRPlayer.gesturedLocomotionManager?.stickOutputX ?? 0);
             }
         }
     }
@@ -119,15 +123,20 @@ namespace ValheimVRMod.Patches {
                 var joystick = VRControls.instance.GetJoyLeftStickY();
 
                 //add deadzone to ship control for forward and backward so its harder to accidentally change speed
-                if (Player.m_localPlayer?.GetControlledShip())
+                if (Player.m_localPlayer.IsAttached())
                 {
                     if(joystick > -0.9f && joystick < 0.9f)
                     {
                         __result = 0f;
-                        return;
                     }
+                    else
+                    {
+                        __result += joystick;
+                    }
+                    return;
                 }
-                __result = __result + joystick + (VRPlayer.gesturedLocomotionManager?.stickOutputY?? 0);
+
+                __result = __result + VRControls.smoothWalkSpeed / VHVRConfig.AutoRunThreshold() + (VRPlayer.gesturedLocomotionManager?.stickOutputY?? 0);
             }
         }
     }
@@ -501,7 +510,7 @@ namespace ValheimVRMod.Patches {
                 run = run || ZInput_GetJoyRightStickY_Patch.holdingRun;
             }
             
-            run = run || (VRPlayer.gesturedLocomotionManager?.isRunning?? false);
+            run = run || VRControls.isAutoRunActive || (VRPlayer.gesturedLocomotionManager?.isRunning?? false);
         }
 
         private static void handleRunToggle(ref bool run)

--- a/ValheimVRMod/Utilities/VHVRConfig.cs
+++ b/ValheimVRMod/Utilities/VHVRConfig.cs
@@ -108,16 +108,19 @@ namespace ValheimVRMod.Utilities
         private static ConfigEntry<bool> smoothSnapTurn;
         private static ConfigEntry<float> smoothSnapSpeed;
         private static ConfigEntry<bool> charaterMovesWithHeadset;
+        private static ConfigEntry<bool> roomScaleMovement;
         private static ConfigEntry<bool> roomScaleSneaking;
         private static ConfigEntry<float> roomScaleSneakHeight;
         private static ConfigEntry<bool> exclusiveRoomScaleSneak;
         private static ConfigEntry<string> gesturedLocomotion;
         private static ConfigEntry<float> gesturedJumpPreparationHeight;
         private static ConfigEntry<float> gesturedJumpMinSpeed;
+        private static ConfigEntry<float> walkSpeedSmoothener;
         private static ConfigEntry<float> swingSpeedRequirement;
         private static ConfigEntry<bool> momentumScalesAttackDamage;
         private static ConfigEntry<float> altPieceRotationDelay;
         private static ConfigEntry<bool> runIsToggled;
+        private static ConfigEntry<float> autoRunThreshold;
         private static ConfigEntry<bool> viewTurnWithMountedAnimal;
         private static ConfigEntry<bool> advancedBuildMode;
         private static ConfigEntry<bool> freePlaceAutoReturn;
@@ -641,6 +644,10 @@ namespace ValheimVRMod.Utilities
                                           "CharaterMovesWithHeadset",
                                           true,
                                           "When set to true, roomscale movement of the headset controls character locomotion; when set to false, movement of the headset makes the character lean.");
+            roomScaleMovement = config.Bind("Controls",
+                                          "RoomScaleMovement",
+                                          true,
+                                          "Enable room scale movement. Recommended to turn off when using VR treadmills");
             roomScaleSneaking = config.Bind("Controls",
                                           "RoomScaleSneaking",
                                           false,
@@ -671,6 +678,11 @@ namespace ValheimVRMod.Utilities
                                           0.75f,
                                           new ConfigDescription("The minimum vertical head speed to trigger a jump",
                                           new AcceptableValueRange<float>(0.25f, 3f)));
+            walkSpeedSmoothener = config.Bind("Controls",
+                                          "WalkSpeedSmoothener",
+                                          0f,
+                                          new ConfigDescription("Smoothener for making walk speed change more gradual. Recommnended to set to 0.5f when using VR treadmills.",
+                                          new AcceptableValueRange<float>(0f, 1f)));
             dominantHand = config.Bind("Controls",
                                         "DominantHand",
                                         "Right",
@@ -703,6 +715,11 @@ namespace ValheimVRMod.Utilities
                                        "RunIsToggled",
                                        true,
                                        "Determine whether or not you need to hold run or it is a toggle. Keep it as toggle (true) to have your thumb free when sprinting.");
+            autoRunThreshold = config.Bind("Controls",
+                                            "AutoRunThreshold",
+                                            1f,
+                                            new ConfigDescription("The threshold of stick Y-input at which run is triggered. Set to 1 to disable Y-input-triggered auto-run. Recommended to set to 0.6f when using VR treadmills.",
+                                            new AcceptableValueRange<float>(0.5f, 1f)));
             viewTurnWithMountedAnimal = config.Bind("Controls",
                                        "ViewTurnWithMountedAnimal",
                                        false,
@@ -1320,6 +1337,11 @@ namespace ValheimVRMod.Utilities
             return charaterMovesWithHeadset.Value;
         }
 
+        public static bool RoomScaleMovement()
+        {
+            return roomScaleMovement.Value;
+        }
+
         public static bool RoomScaleSneakEnabled() {
             return roomScaleSneaking.Value;
         }
@@ -1358,6 +1380,10 @@ namespace ValheimVRMod.Utilities
             return gesturedJumpMinSpeed.Value;
         }
 
+        public static float WalkSpeedSmoothener()
+        {
+            return walkSpeedSmoothener.Value;
+        }
         public static float GetNearClipPlane()
         {
             return nearClipPlane.Value;
@@ -1376,6 +1402,21 @@ namespace ValheimVRMod.Utilities
         public static bool ToggleRun()
         {
             return runIsToggled.Value;
+        }
+
+        public static float AutoRunThreshold()
+        {
+            return autoRunThreshold.Value;
+        }
+
+        public static float AutoRunActivationThreshold()
+        {
+            return autoRunThreshold.Value >= 0.99f ? Mathf.Infinity :  Mathf.Min(autoRunThreshold.Value + 0.33f, 0.99f);
+        }
+
+        public static float AutoRunDeactivationThreshold()
+        {
+            return autoRunThreshold.Value / 2;
         }
 
         public static bool LeftHanded()

--- a/ValheimVRMod/VRCore/UI/VRControls.cs
+++ b/ValheimVRMod/VRCore/UI/VRControls.cs
@@ -81,6 +81,9 @@ namespace ValheimVRMod.VRCore.UI
             }
         }
 
+        public static float smoothWalkSpeed { get; private set; }
+        public static bool isAutoRunActive { get; private set; }
+
         public static string ToggleMiniMap { get { return "ToggleMiniMap"; } }
 
         public static VRControls instance { get { return _instance; } }
@@ -134,6 +137,30 @@ namespace ValheimVRMod.VRCore.UI
 
         void FixedUpdate()
         {
+            float joystickX = GetJoyLeftStickX();
+            float joystickY = GetJoyLeftStickY();
+            if (Time.deltaTime == 0 ||
+                smoothWalkSpeed == float.NaN ||
+                Mathf.Abs(Mathf.Abs(joystickY) - VHVRConfig.AutoRunThreshold()) < Mathf.Abs(Mathf.Abs(smoothWalkSpeed) - VHVRConfig.AutoRunThreshold()))
+            {
+                smoothWalkSpeed = joystickY;
+            }
+            else
+            {
+                smoothWalkSpeed = Mathf.MoveTowards(smoothWalkSpeed, joystickY, Time.deltaTime / VHVRConfig.WalkSpeedSmoothener());
+            }
+
+            float squareSpeed = joystickX * joystickX + VRControls.smoothWalkSpeed * VRControls.smoothWalkSpeed;
+
+            if (squareSpeed > VHVRConfig.AutoRunActivationThreshold() * VHVRConfig.AutoRunActivationThreshold())
+            {
+                isAutoRunActive = true;
+            }
+            else if (squareSpeed < VHVRConfig.AutoRunDeactivationThreshold() * VHVRConfig.AutoRunDeactivationThreshold())
+            {
+                isAutoRunActive = false;
+            }
+
             updateAltPieceRotationTimer();
             updateAltMapZoomTimer();
         }

--- a/ValheimVRMod/VRCore/VRPlayer.cs
+++ b/ValheimVRMod/VRCore/VRPlayer.cs
@@ -1344,7 +1344,7 @@ namespace ValheimVRMod.VRCore
         void DoRoomScaleMovement(float deltaTime)
         {
             var player = getPlayerCharacter();
-            if (_vrCam == null || player == null || player.gameObject == null || player.IsAttached())
+            if (_vrCam == null || player == null || player.gameObject == null || player.IsAttached() || !VHVRConfig.RoomScaleMovement())
             {
                 return;
             }


### PR DESCRIPTION
1. Add walk speed smoothener to make treadmill-controlled walking speed more stable

2. Allow controlling walk speed and walk/run withe same joystick so that treadmill-emulated stick input can be used to trigger running

3. Restore the option to disable roomscale to allow leaning when using treadmill