### PR TITLE
Optimization: only update button states when laser pointer is active

### DIFF
--- a/ValheimVRMod/VRCore/UI/VRGUI.cs
+++ b/ValheimVRMod/VRCore/UI/VRGUI.cs
@@ -397,12 +397,19 @@ namespace ValheimVRMod.VRCore.UI
 
         public void OnPointerTracking(object p, PointerEventArgs e)
         {
-            if (isUiPanel(e.target))
+            if (!_leftPointer.pointerIsActive() && !_rightPointer.pointerIsActive())
             {
-                SoftwareCursor.simulatedMousePosition =
-                    convertLocalUiPanelCoordinatesToCursorCoordinates(e.target.InverseTransformPoint(e.position));
-                _inputModule.UpdateButtonStates(e.buttonStateLeft, e.buttonStateRight, false);
+                return;
             }
+
+            if (!isUiPanel(e.target))
+            {
+                return;
+            }
+
+            SoftwareCursor.simulatedMousePosition =
+                convertLocalUiPanelCoordinatesToCursorCoordinates(e.target.InverseTransformPoint(e.position));
+            _inputModule.UpdateButtonStates(e.buttonStateLeft, e.buttonStateRight, false);
         }
 
         private Vector2 convertLocalUiPanelCoordinatesToCursorCoordinates(Vector3 localCoordinates)

--- a/ValheimVRMod/VRCore/UI/VRGUI.cs
+++ b/ValheimVRMod/VRCore/UI/VRGUI.cs
@@ -399,6 +399,7 @@ namespace ValheimVRMod.VRCore.UI
         {
             if (!_leftPointer.pointerIsActive() && !_rightPointer.pointerIsActive())
             {
+                // Updating button states are expensive and only needs to be done when the user is using a laser pointer.
                 return;
             }
 


### PR DESCRIPTION
Button state updates are expensive (~0.5% of current CPU time)