### PR TITLE
Fix gizmo anglesnap culture

### DIFF
--- a/ValheimVRMod/Scripts/BuildingManager.cs
+++ b/ValheimVRMod/Scripts/BuildingManager.cs
@@ -1536,7 +1536,7 @@ namespace ValheimVRMod.Scripts
                 var ceaX = Mathf.Round(currentEulerAngle.x * 100) / 100;
                 var ceaY = Mathf.Round(currentEulerAngle.y * 100) / 100;
                 var ceaZ = Mathf.Round(currentEulerAngle.z * 100) / 100;
-                var rotSnapAngleText = rotate ? snapAngleMultiplier.ToString() : "-";
+                var rotSnapAngleText = rotate ? snapAngleMultiplier.ToString("0.##", CultureInfo.InvariantCulture) : "-";
                 rotationText.text = "X "+ ceaX + "|Y "+ ceaY + "|Z " + ceaZ 
                                 + "\n" +dir.ToUpper() + " " + rotateAngle 
                                 + "\n Snap Angle : " + rotSnapAngleText;

--- a/ValheimVRMod/Scripts/BuildingManager.cs
+++ b/ValheimVRMod/Scripts/BuildingManager.cs
@@ -6,6 +6,7 @@ using ValheimVRMod.Utilities;
 using ValheimVRMod.VRCore;
 using ValheimVRMod.VRCore.UI;
 using Valve.VR;
+using System.Globalization;
 
 namespace ValheimVRMod.Scripts
 {

--- a/ValheimVRMod/Scripts/BuildingManager.cs
+++ b/ValheimVRMod/Scripts/BuildingManager.cs
@@ -1537,7 +1537,7 @@ namespace ValheimVRMod.Scripts
                 var ceaX = Mathf.Round(currentEulerAngle.x * 100) / 100;
                 var ceaY = Mathf.Round(currentEulerAngle.y * 100) / 100;
                 var ceaZ = Mathf.Round(currentEulerAngle.z * 100) / 100;
-                var rotSnapAngleText = rotate ? snapAngleMultiplier.ToString("0.##", CultureInfo.InvariantCulture) : "-";
+                var rotSnapAngleText = rotate ? snapAngleMultiplier.ToString("0.##", CultureInfo.InvariantCulture).Replace('.', ',') : "-";
                 rotationText.text = "X "+ ceaX + "|Y "+ ceaY + "|Z " + ceaZ 
                                 + "\n" +dir.ToUpper() + " " + rotateAngle 
                                 + "\n Snap Angle : " + rotSnapAngleText;

--- a/ValheimVRMod/Scripts/BuildingManager.cs
+++ b/ValheimVRMod/Scripts/BuildingManager.cs
@@ -6,7 +6,6 @@ using ValheimVRMod.Utilities;
 using ValheimVRMod.VRCore;
 using ValheimVRMod.VRCore.UI;
 using Valve.VR;
-using System.Globalization;
 
 namespace ValheimVRMod.Scripts
 {
@@ -1537,7 +1536,7 @@ namespace ValheimVRMod.Scripts
                 var ceaX = Mathf.Round(currentEulerAngle.x * 100) / 100;
                 var ceaY = Mathf.Round(currentEulerAngle.y * 100) / 100;
                 var ceaZ = Mathf.Round(currentEulerAngle.z * 100) / 100;
-                var rotSnapAngleText = rotate ? snapAngleMultiplier.ToString("0.##", CultureInfo.InvariantCulture).Replace('.', ',') : "-";
+                var rotSnapAngleText = rotate ? snapAngleMultiplier.ToString() : "-";
                 rotationText.text = "X "+ ceaX + "|Y "+ ceaY + "|Z " + ceaZ 
                                 + "\n" +dir.ToUpper() + " " + rotateAngle 
                                 + "\n Snap Angle : " + rotSnapAngleText;

--- a/ValheimVRMod/Utilities/VHVRConfig.cs
+++ b/ValheimVRMod/Utilities/VHVRConfig.cs
@@ -1779,7 +1779,7 @@ namespace ValheimVRMod.Utilities
         public static float[] BuildAngleSnap()
         {
             //"22.5, 15, 10, 5, 2.5, 1, 0.5"
-            float[] snapList = Array.ConvertAll(buildAngleSnap.Value.Split(','), float.Parse);
+            float[] snapList = Array.ConvertAll(buildAngleSnap.Value.Split(','), s => float.Parse(s.Trim(), System.Globalization.CultureInfo.InvariantCulture));
             return snapList;
         }
 


### PR DESCRIPTION
There was a problem with the angle values in the native gizmo snaps when Advanced Build was enabled.

It seems that, when using the Italian number format, the game fails to correctly parse float values such as:
26, 22.5, 10, 5, 2.5, 1, 0.5, 0.1, 0.05, 0.01
and instead interprets them incorrectly as:
26, 225, 10, 5, 25, 1, 5, 1, 5, 1

I've made changes to VHVRConfig.cs and BuildingManager.cs, and now the values are parsed correctly using CultureInfo.InvariantCulture.

On Discord, I shared the compiled file with a working fix using this code in VHVRConfig.cs:
```
return Array.ConvertAll(buildAngleSnap.Value.Split(','), s => float.Parse(s.Trim(), System.Globalization.CultureInfo.InvariantCulture));
```

In this pull request, I updated it to better match the original structure:
```
float[] snapList = Array.ConvertAll(buildAngleSnap.Value.Split(','), 
    s => float.Parse(s.Trim(), System.Globalization.CultureInfo.InvariantCulture));
return snapList;
```
This is not only my first pull request on this project — it's actually my first pull request ever 😅
Let me know if there's anything I should improve!