### PR TITLE
Move weapon collider estimation before weapon wield initialization

### DIFF
--- a/ValheimVRMod/Patches/EquipPatches.cs
+++ b/ValheimVRMod/Patches/EquipPatches.cs
@@ -237,6 +237,12 @@ namespace ValheimVRMod.Patches {
                 return;
             }
 
+            var weaponCol = StaticObjects.rightWeaponCollider().GetComponent<WeaponCollision>();
+            // Weapon collider should be estimated before weapon wield initialization since
+            // the latter may move the weapon and interfere with collider estimation.
+            weaponCol.setColliderParent(
+                meshFilter, handPosition: ___m_rightItemInstance.transform.parent.position, ___m_rightItem, true);
+
             LocalWeaponWield weaponWield = EquipScript.isSpearEquipped() ? ___m_rightItemInstance.AddComponent<SpearWield>() : ___m_rightItemInstance.AddComponent<LocalWeaponWield>();
             weaponWield.Initialize(Player.m_localPlayer.GetRightItem(), ___m_rightItem, isDominantHandWeapon: true);
 
@@ -250,9 +256,6 @@ namespace ValheimVRMod.Patches {
                 (meshFilter.gameObject.AddComponent<ThrowableManager>()).weaponWield = weaponWield;
             }
 
-            var weaponCol = StaticObjects.rightWeaponCollider().GetComponent<WeaponCollision>();
-            weaponCol.setColliderParent(
-                meshFilter, handPosition: ___m_rightItemInstance.transform.parent.position, ___m_rightItem, true);
             switch (EquipScript.getRight())
             {
                 case EquipType.Cultivator:


### PR DESCRIPTION
This will allow better collider estimation especially for the correct detection of weapon direction.