### PR TITLE
Skip dodge patches for non-VR player; allow build without release packaging

### DIFF
--- a/ValheimVRMod/Patches/ControlPatches.cs
+++ b/ValheimVRMod/Patches/ControlPatches.cs
@@ -1252,6 +1252,13 @@ namespace ValheimVRMod.Patches {
     class Player_UpdateDodge_Patch
     {
         public static bool wasDodging = false;
+
+        [HarmonyPrepare]
+        static bool Prepare()
+        {
+            return !VHVRConfig.NonVrPlayer();
+        }
+
         static void Postfix(Player __instance)
         {
             if (VHVRConfig.NonVrPlayer() || __instance != Player.m_localPlayer)
@@ -1306,6 +1313,13 @@ namespace ValheimVRMod.Patches {
     {
         public static float currdodgetimer { get; private set; } = 0f;
         static Vector3 currDodgeDir;
+
+        [HarmonyPrepare]
+        static bool Prepare()
+        {
+            return !VHVRConfig.NonVrPlayer();
+        }
+
         static bool Prefix(Player __instance, float dt, ref bool ___m_beenHitWhileDodging)
         {
             if (__instance != Player.m_localPlayer || !VHVRConfig.UseVrControls())

--- a/ValheimVRMod/ValheimVRMod.csproj
+++ b/ValheimVRMod/ValheimVRMod.csproj
@@ -121,7 +121,7 @@
       <HintPath>..\Unity\build\ValheimVR_Data\Managed\SteamVR_Actions.dll</HintPath>
     </Reference>
   </ItemGroup>
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(SkipReleasePackaging)' != 'true'">
     <Exec Command="make-release.cmd" EnvironmentVariables="
 	    SOLUTION_DIR=$(SolutionDir);
 	    GAME_DIR=$(CommonDir)Valheim\;   


### PR DESCRIPTION
Two small, independent changes, one per commit.

## 1. Skip the dodge patches for a non-VR player

`Player_UpdateDodge_Patch` (postfix on `Player.Update`) and `UpdateDodgeVr`
(prefix on `Player.UpdateDodge`) are pure VR behaviour. Both already bail out at
the top of every call for a non-VR player — `NonVrPlayer()` in the first,
`!UseVrControls()` in the second, and `UseVrControls()` is itself
`useVrControlsValue && !NonVrPlayer()`. So today a player running with
`nonVrPlayer=true` still gets `Player.Update` wrapped and `Player.UpdateDodge`
replaced by a prefix that returns `false` in the VR path, on every player
instance, every frame, only to be told to do nothing.

This adds a `[HarmonyPrepare]` gate to both classes so the patches are simply
never applied in that mode. `Player.Update` and `Player.UpdateDodge` are left
completely untouched, which also keeps `UpdateDodgeVr` out of the way of any
other mod patching `UpdateDodge` on a flatscreen install.

Why the patch-time decision is safe: in `ValheimVRMod.StartValheimVR()`,
`VRManager.InitializeVR()` runs and `failedToInitializeVR` is set *before*
`HarmonyPatcher.DoPatching()`. `failedToInitializeVR` has a private setter with
that single assignment site, and the `nonVrPlayer` config entry is an Immutable
setting, so `VHVRConfig.NonVrPlayer()` has reached its final value by the time
`Prepare()` is evaluated and cannot change afterwards. The existing inline
guards are deliberately left in place, so nothing regresses even if that
ordering ever changes.

There is no existing `[HarmonyPrepare]` usage in the repo to copy, so I used the
plain Harmony convention. Happy to reshape it if you would rather it went
through a shared helper.

### Other classes with the same pattern

I kept this commit to the two dodge classes rather than widening it unasked, but
these classes in the same file gate their entire patch on `NonVrPlayer()` and
look equally eligible:

- `SadleControlPatch`
- `InventoryGui_Awake_Patch`
- `InventoryGrid_GetHoveredElement_Patch`
- `InventoryGui_Update_Patch` (gates on `NonVrPlayer() || !UseVrControls()`)
- `PlayerController_LateUpdate_Patch` — this one is a transpiler whose guard sits
  in the injected helper, so a `Prepare()` gate would skip the IL rewrite
  entirely rather than rewriting it and branching at runtime.

Say the word and I will add them here, or in a follow-up, or leave them alone.

## 2. Allow building without the release packaging step

The `PostBuild` target shells out to `make-release.cmd`, which is Windows-only
and does the full release assembly. That makes it impossible to just compile the
assembly on a machine that cannot run it.

This adds `Condition="'$(SkipReleasePackaging)' != 'true'"` to the target, so
`-p:SkipReleasePackaging=true` compiles without packaging. The property is unset
by default, so the normal Visual Studio build is byte-for-byte unchanged.

## Testing

Being straight with you about this: I did not build or run this branch. Building
VHVR needs Windows and the Unity-side assets, and this was written on Linux, so
I have no way to produce a binary from the branch here.

What I can say is that both changes are in use in a four-server deployment,
in a build made from `a10f24f` with these same edits applied, and that the
packaging condition is how that build gets compiled at all. I have not run a
deliberate dodge-regression pass against it, so please read that as "in
production use", not as "tested". The branch here is those same edits reapplied
by hand onto current `master` (`50d333d`), so the code is equivalent but these
specific commits are unbuilt and unrun.

Reviewing the `Prepare()` ordering argument above is probably worth more than my
testing claim; if the ordering reasoning is wrong, the change is wrong.
