### PR TITLE
Remove unused using directive from Pose.cs

### DIFF
--- a/ValheimVRMod/Utilities/Pose.cs
+++ b/ValheimVRMod/Utilities/Pose.cs
@@ -1,4 +1,3 @@
-using Microsoft.SqlServer.Server;
 using UnityEngine;
 using ValheimVRMod.Patches;
 using ValheimVRMod.Scripts;


### PR DESCRIPTION
`ValheimVRMod/Utilities/Pose.cs` line 1 is `using Microsoft.SqlServer.Server;`. Nothing in the file references any type from that namespace; it was introduced in 50d333d ("Refine gestured draw logic") alongside the gestured-draw changes.

It builds in Visual Studio only because `ValheimVRMod.csproj` has `<Reference Include="System.Data" />`, and the Windows reference assemblies supply `Microsoft.SqlServer.Server` from there. Compiling the same sources against the game's own managed assemblies — the set BepInEx loads at runtime, which has no `System.Data` — fails on that line:

```
ValheimVRMod/Utilities/Pose.cs(1,17): error CS0234: The type or namespace name `SqlServer' does not exist in the namespace `Microsoft'. Are you missing an assembly reference?
```

We hit this compiling the mod with Mono's `mcs` against the game assemblies rather than with Visual Studio. The fix is deleting the one line; no other change.
