### PR TITLE
Restore ShieldBlock attachment lost in 666124e6 (shields do not block or parry in VR)

### DIFF
--- a/ValheimVRMod/Patches/EquipPatches.cs
+++ b/ValheimVRMod/Patches/EquipPatches.cs
@@ -463,6 +463,11 @@ namespace ValheimVRMod.Patches
                 case EquipType.Lantern:
                     return;
                 case EquipType.Shield:
+                    // Attaching ShieldBlock is what makes a shield block and parry at all: ShieldBlock.Awake()
+                    // assigns the static ShieldBlock.instance that PatchBlockAttack reads in ShieldPatches.cs.
+                    // This call was lost in 666124e6 when the ".itemName = ___m_leftItem" tail of the statement
+                    // was removed along with the field; the field was write-only, so it is not restored here.
+                    meshFilter.gameObject.AddComponent<ShieldBlock>();
                     return;
             }
 


### PR DESCRIPTION
## Symptom

In VR, an equipped offhand shield never blocks and never parries. Damage is taken in full, and the parry stagger never triggers. Non-shield blocking (fists, two-handed weapons, crossbow) still works, which is why this reads as "shields are broken" rather than "blocking is broken".

## Cause

`666124e6` ("Migrate to cache weapon collision using item hash instead of object name", authored 2026-05-07 20:22:33 -0400) removed the only line that ever attached `ShieldBlock` to the shield instance:

```diff
@@ -456,11 +463,10 @@ namespace ValheimVRMod.Patches
                 case EquipType.Lantern:
                     return;
                 case EquipType.Shield:
-                    meshFilter.gameObject.AddComponent<ShieldBlock>().itemName = ___m_leftItem;
                     return;
             }
```

and, in the same commit, the field it assigned:

```diff
--- a/ValheimVRMod/Scripts/Block/ShieldBlock.cs
+++ b/ValheimVRMod/Scripts/Block/ShieldBlock.cs
@@ -6,7 +6,6 @@ using Valve.VR;
 namespace ValheimVRMod.Scripts.Block {
     public class ShieldBlock : Block {
 
-        public string itemName;
         private const float MIN_PARRY_ENTRY_SPEED = 1.5f;
```

The intent of the commit was to stop using `___m_leftItem` (a string) and use the item hash instead. In the shield case, however, the string was not an argument: it was the right-hand side of a trailing `.itemName = ___m_leftItem` assignment. Deleting the string therefore deleted the whole statement, including the `AddComponent<ShieldBlock>()` call, which was not the intent.

The neighbouring cases in the same `switch` survived precisely because their string was an argument and could be swapped for the hash in place. From the same commit:

```diff
                 case EquipType.Crossbow:
                     CrossbowManager crossbowManager = ___m_leftItemInstance.AddComponent<CrossbowManager>();
-                    crossbowManager.Initialize(Player.m_localPlayer.GetLeftItem(), ___m_leftItem, isDominantHandWeapon: false);
+                    crossbowManager.Initialize(Player.m_localPlayer.GetLeftItem(), hash, isDominantHandWeapon: false);
```

## Why the compiler did not catch it

`ShieldBlock.itemName` was write-only. At `666124e6^` the identifier `ShieldBlock.itemName` occurs exactly twice in the tree: the declaration at `ValheimVRMod/Scripts/Block/ShieldBlock.cs:9` and the single write at `ValheimVRMod/Patches/EquipPatches.cs:459`. Nothing read it. Removing the field and its only writer in one commit is therefore a clean compile, with no warning, even though the `AddComponent` call disappeared with them.

(For contrast, `WeaponWield.itemName` in the same tree does have readers — `WeaponWield.cs:61`, `:75-96`, `:199` — so this is a genuine absence of readers for the `ShieldBlock` field, not a search that failed to find them.)

## Consequence in the block path

`ShieldBlock.instance` is assigned in `ShieldBlock.Awake()`. With the component never attached, `Awake()` never runs and `ShieldBlock.instance` stays null for the whole session. Both halves of shield defence are keyed off that static:

- Blocking, `ValheimVRMod/Patches/ShieldPatches.cs:49`:
  ```csharp
  if (ShieldBlock.instance?.isBlocking() ?? false)
  ```
  A null instance means this branch is never taken, so a shield is never considered to be blocking.

- Parrying, `ValheimVRMod/Patches/ShieldPatches.cs:43`:
  ```csharp
  ___m_blockTimer = ShieldBlock.instance?.blockTimer ?? Block.blockTimerNonParry;
  ```
  A null instance forces `Block.blockTimerNonParry`, which is `9999f` (`ValheimVRMod/Scripts/Block/Block.cs:15`). Valheim treats a block as a parry only while the block timer is within `blockTimerTolerance`, `0.3f` (`Block.cs:14`). `9999f` can never satisfy that, so a shield can never parry either, independently of the blocking check above.

`ValheimVRMod/Patches/ControlPatches.cs:774` reads the same static and is affected in the same way.

## Binary evidence that the released mod did attach it

Release `v0.9.21` (published 2026-03-01, `vhvr-0.9.21.zip`, sha256 `df4569977a8052e6f86272aab2f89d0df93c31de9a5024248f090dcafeae6ef8`; contained `BepInEx/plugins/ValheimVRMod.dll`, sha256 `99fc2ca91a2d08fd6cbcd5908b99da78544d121385547e33c6763a5516943a87`) predates `666124e6`. Walking its IL and resolving every `call`/`callvirt` token:

```
ValheimVRMod.Patches.PatchSetLeftHandEquipped::Postfix  ->  AddComponent<ShieldBlock>
TOTAL AddComponent<ShieldBlock> call sites: 1
```

and its `ShieldBlock` still declares the field:

```
ShieldBlock declared fields:
  String itemName
  ...
```

The same scan over a build of current `master` reports:

```
TOTAL AddComponent<ShieldBlock> call sites: 0
```

As a control that the scan detects attachments when they exist, `AddComponent<WeaponBlock>` reports 3 call sites in both the `v0.9.21` release and the current `master` build.

## Still present on master

`master` is at `50d333d4fcae84181cf4c21eb6e2aa0ad486af32`; `GET /repos/brandonmousseau/vhvr-mod/compare/50d333d...master` returns `"status": "identical"`, `ahead_by: 0`. The 0-call-site result above was measured on a build of exactly that tree, so the regression is live on master today.

## The change

Restore the attachment at the same site, without the field:

```csharp
case EquipType.Shield:
    meshFilter.gameObject.AddComponent<ShieldBlock>();
    return;
```

`itemName` is deliberately not reintroduced. It had no reader before it was deleted, so restoring it would only add a dead field.

The `GameObject` is the same one the pre-regression code used: `meshFilter.gameObject`, where `meshFilter` is `___m_leftItemInstance.GetComponentInChildren<MeshFilter>()`. This is verifiable in the IL. In the `v0.9.21` release the call is preceded by the bytes `07 6F BF 00 00 0A`, and in a build of this branch by `07 6F 90 00 00 0A` -- in both cases `ldloc.1` (the `MeshFilter` local) followed by `callvirt Component::get_gameObject`, then the `AddComponent` call. The differing middle bytes are only the member-reference token, which is expected to differ between assemblies.

One file, five added lines, four of which are an explanatory comment. No behaviour outside the shield case is touched.

## Verification

Compiled. Because the project does not build out of the box outside Visual Studio, this was built with Mono 6.8.0.105 `mcs` (`-target:library -sdk:4.6 -langversion:latest`) against the Valheim, Unity 2020.3, BepInEx 5.4.21 and SteamVR reference assemblies. Four pre-existing, unrelated build blockers had to be worked around locally and are **not** part of this PR, since they are orthogonal to the bug:

1. `ValheimVRMod/Utilities/Pose.cs:1` has a stray `using Microsoft.SqlServer.Server;` which does not resolve outside a Visual Studio reference set.
2. Three `x is null` constant patterns (`Patches/UIPatches.cs`, `Scripts/LocalWeaponWield.cs`, `VRCore/UI/EnemyHudManager.cs`) that Mono's `mcs` (C# 7.3 maximum) rejects.
3. `SteamVR_Input_Sources.LeftAnkle` / `RightAnkle` in `VRCore/BodyTracking/SteamVRBodyTrackingProvider.cs` are absent from older `SteamVR.dll`.
4. The `PostBuild` step invokes `make-release.cmd`, which is Windows-only.

The identical workaround set was applied to a pristine `master` tree and to this branch, and both compiled cleanly, so the only difference between the two builds is the change in this PR. The resulting assemblies differ (sha256 `362063416dea7d4f7d6377b92ee0e22c9dd445761297df7e7aa2b72d20281010` for `master`, `f608dd05d347c8ea9c9180cb743097c17dac593be6fbb93ffff5a78c646b7f12` for this branch), and the IL scan of the branch build reports:

```
ValheimVRMod.Patches.PatchSetLeftHandEquipped::Postfix  ->  AddComponent<ShieldBlock>
TOTAL AddComponent<ShieldBlock> call sites: 1
```

matching `v0.9.21`.

Confirmed in a headset on 2026-08-26 with the equivalent fix applied at the same patch site: shield blocking works, and a parry staggers the attacker.
