### PR TITLE
Fix Index keyboard handling and staff controls

### DIFF
--- a/ValheimVRMod/Patches/TextInputPatches.cs
+++ b/ValheimVRMod/Patches/TextInputPatches.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using System.Threading;
 using GUIFramework;
 using HarmonyLib;
 using UnityEngine;
@@ -14,22 +13,20 @@ namespace ValheimVRMod.Patches {
 
     [HarmonyPatch(typeof(TextInput), "Show")]
     class PatchTextInputAwake {
-        
-        private static TextInput instance;
-
         public static void Postfix(TextInput __instance) {
             if (VHVRConfig.UseVrControls()) {
-                instance = __instance;
-                if (VHVRConfig.AutoOpenKeyboardOnInteract() || instance.m_topic.text == "ChatText")
+                bool isChatInput = __instance.m_topic.text == "ChatText";
+                if (VHVRConfig.AutoOpenKeyboardOnInteract() || isChatInput)
                 {
-                    // TODO: find out why portal tag and sign text input dialog can no longer be visible after chat input is used once.
-                    InputManager.start(null, null, instance.m_inputField, returnOnClose: false, OnClose);
+                    InputManager.start(
+                        null,
+                        null,
+                        __instance.m_inputField,
+                        returnOnClose: false,
+                        closedAction: delegate { __instance.OnEnter(); },
+                        chatInput: isChatInput);
                 }
             }
-        }
-
-        private static void OnClose() {
-            instance.OnEnter();
         }
     }
     
@@ -128,13 +125,27 @@ namespace ValheimVRMod.Patches {
         public static float closeTime;
         public static bool triggerReturn;
 
-        public static void start(InputField inputField, TMP_InputField inputFieldTmp, GuiInputField inputFieldGui, bool returnOnClose = false, UnityAction closedAction = null) {
+        public static void start(
+            InputField inputField,
+            TMP_InputField inputFieldTmp,
+            GuiInputField inputFieldGui,
+            bool returnOnClose = false,
+            UnityAction closedAction = null,
+            bool chatInput = false) {
+            if (_keyboardOpen)
+            {
+                return;
+            }
+
             // TODO: consider enforcing the check that one and only one among inputField, inputFieldGui, and inputFieldTmp is non-null.
             _inputField = inputField;
             _inputFieldGui = inputFieldGui;
             _inputFieldTmp = inputFieldTmp;
             _returnOnClose = returnOnClose;
             _closedAction = closedAction;
+            _chatInput = chatInput;
+            _keyboardOpen = true;
+            triggerReturn = false;
             
             if (_inputField != null && _inputField.text == "...") {
                 _inputField.text = "";
@@ -157,31 +168,53 @@ namespace ValheimVRMod.Patches {
             SteamVR.instance.overlay.ShowKeyboard(0, 0, 0, "TextInput", 256, _inputField != null ? _inputField.text : _inputFieldTmp != null ? _inputFieldTmp.text : _inputFieldGui.text, 1);
         }
 
+        private static bool _keyboardOpen;
+        private static bool _chatInput;
+
         private static void OnKeyboardClosed(VREvent_t args) {
+            if (!_keyboardOpen)
+            {
+                return;
+            }
+
+            InputField inputField = _inputField;
+            TMP_InputField inputFieldTmp = _inputFieldTmp;
+            GuiInputField inputFieldGui = _inputFieldGui;
+            UnityAction closedAction = _closedAction;
+            bool returnOnClose = _returnOnClose;
+            bool chatInput = _chatInput;
+            _inputField = null;
+            _inputFieldTmp = null;
+            _inputFieldGui = null;
+            _closedAction = null;
+            _returnOnClose = false;
+            _chatInput = false;
+            _keyboardOpen = false;
+
             closeTime = Time.fixedTime;
             StringBuilder textBuilder = new StringBuilder(256);
             int caretPosition = (int)SteamVR.instance.overlay.GetKeyboardText(textBuilder, 256);
             string text = textBuilder.ToString();
 
-            if (_inputField)
+            if (inputField)
             {
-                _inputField.caretPosition = caretPosition;
-                _inputField.text = text;
+                inputField.caretPosition = caretPosition;
+                inputField.text = text;
             }
 
-            if (_inputFieldTmp)
+            if (inputFieldTmp)
             {
-                _inputFieldTmp.caretPosition = caretPosition;
-                _inputFieldTmp.text = text;
+                inputFieldTmp.caretPosition = caretPosition;
+                inputFieldTmp.text = text;
             }
 
-            if (_inputFieldGui)
+            if (inputFieldGui)
             {
-                _inputFieldGui.caretPosition = caretPosition;
-                _inputFieldGui.text = text;
+                inputFieldGui.caretPosition = caretPosition;
+                inputFieldGui.text = text;
             }
 
-            if (Scripts.QuickAbstract.shouldStartChat)
+            if (chatInput)
             {
                 if (text != "")
                 {
@@ -204,12 +237,16 @@ namespace ValheimVRMod.Patches {
             }
             Scripts.QuickAbstract.shouldStartChat = false;
 
-            triggerReturn = _returnOnClose;
+            triggerReturn = returnOnClose;
 
             // If return is to be triggered, we will wait until then to fire close action.
-            if (!_returnOnClose)
+            if (!returnOnClose)
             {
-                _closedAction?.Invoke();
+                closedAction?.Invoke();
+            }
+            else
+            {
+                _closedAction = closedAction;
             }
         }
 
@@ -218,7 +255,9 @@ namespace ValheimVRMod.Patches {
             if (triggerReturn && key == KeyCode.Return) {
                 result = true;
                 triggerReturn = false;
-                new Thread(()=>_closedAction?.Invoke()).Start();
+                UnityAction closedAction = _closedAction;
+                _closedAction = null;
+                closedAction?.Invoke();
                 return false;
             }
 

--- a/ValheimVRMod/Scripts/LocalWeaponWield.cs
+++ b/ValheimVRMod/Scripts/LocalWeaponWield.cs
@@ -147,6 +147,7 @@ namespace ValheimVRMod.Scripts
                 isAiming = false;
             }
 
+            localWeaponTip = transform.position + (weaponLength - distanceBetweenGripAndRearEnd) * weaponForward;
             updateCrosshair();
 
             if (twoHandedState != TwoHandedState.SingleHanded)
@@ -190,7 +191,6 @@ namespace ValheimVRMod.Scripts
             lastRenderedTransform.SetPositionAndRotation(transform.position, transform.rotation);
             lastRenderedTransform.localScale = Vector3.one;
             lastRenderedTransform.SetParent(null, true);
-            localWeaponTip = transform.position + (weaponLength - distanceBetweenGripAndRearEnd) * weaponForward;
             playerSync?.UpdateWeaponTransform(transform.localPosition, transform.localRotation);
 
             return weaponForward;
@@ -439,7 +439,9 @@ namespace ValheimVRMod.Scripts
 
             crosshair.SetActive(VHVRConfig.ShowStaticCrosshair());
             crosshair.transform.SetParent(transform, false);
-            crosshair.transform.position = transform.position + CrosshairManager.WEAPON_CROSSHAIR_DISTANCE * weaponForward;
+            var crosshairOrigin = EquipScript.CurrentOffHandEquipType() == EquipType.Magic ||
+                EquipScript.CurrentMainHandEquipType() == EquipType.Magic ? localWeaponTip : transform.position;
+            crosshair.transform.position = crosshairOrigin + CrosshairManager.WEAPON_CROSSHAIR_DISTANCE * weaponForward;
             crosshair.transform.localRotation = Quaternion.identity;
             crosshair.SetActive(isAiming);
         }

--- a/ValheimVRMod/Scripts/MagicWeaponManager.cs
+++ b/ValheimVRMod/Scripts/MagicWeaponManager.cs
@@ -15,7 +15,7 @@ namespace ValheimVRMod.Scripts
 
         private static readonly HashSet<string> SWING_LAUNCH_MAGIC_STAFF_NAMES =
             new HashSet<string>(new string[] {
-                "$item_stafffireball", "$item_staffgreenroots", "$item_staffclusterbomb", "$item_staffredtroll" });
+                "$item_staffgreenroots", "$item_staffclusterbomb", "$item_staffredtroll" });
         private static readonly HashSet<string> OPPOSITE_HAND_SUMMONER_NAMES =
             new HashSet<string>(new string[] { "$item_staffskeleton" });
 
@@ -133,6 +133,13 @@ namespace ValheimVRMod.Scripts
 
         public static Vector3 GetProjectileSpawnPoint(Attack attack)
         {
+            // Projectiles should originate from the actual tip of the staff, not the pointer origin or the center/front-top of the weapon.
+            // This fixes staff spells on Index controllers and makes swing-launch fire staffs behave like the tip-based spell casts.
+            if (LocalWeaponWield.localWeaponTip != Vector3.zero)
+            {
+                return LocalWeaponWield.localWeaponTip;
+            }
+
             var offsetDirection =
                 CanSummonWithOppositeHand() ?
                 (VRPlayer.isRightHandMainWeaponHand ? VRPlayer.rightHandBone.up : VRPlayer.leftHandBone.up) :

--- a/ValheimVRMod/VRCore/BodyTracking/SteamVRBodyTrackingProvider.cs
+++ b/ValheimVRMod/VRCore/BodyTracking/SteamVRBodyTrackingProvider.cs
@@ -24,16 +24,15 @@ namespace ValheimVRMod.VRCore.BodyTracking
         private static SteamVR_Action_Pose bodyPose;
 
         // Each joint maps to one or more SteamVR input sources in priority order (highest
-        // priority first). Feet prefer the Foot tracker role but fall back to the Ankle
-        // role, so a user who assigned either role in SteamVR gets working tracking.
+        // priority first). The installed Valheim SteamVR API exposes the Foot tracker roles.
         // SteamVR resolves each role to exactly one device, so the fallback (picking the
         // first source with a valid pose) has to happen here rather than in the bindings.
         private static readonly Dictionary<BodyJoint, SteamVR_Input_Sources[]> JointSources =
             new Dictionary<BodyJoint, SteamVR_Input_Sources[]>
             {
                 { BodyJoint.Waist, new[] { SteamVR_Input_Sources.Waist } },
-                { BodyJoint.LeftFoot, new[] { SteamVR_Input_Sources.LeftFoot, SteamVR_Input_Sources.LeftAnkle } },
-                { BodyJoint.RightFoot, new[] { SteamVR_Input_Sources.RightFoot, SteamVR_Input_Sources.RightAnkle } },
+                { BodyJoint.LeftFoot, new[] { SteamVR_Input_Sources.LeftFoot } },
+                { BodyJoint.RightFoot, new[] { SteamVR_Input_Sources.RightFoot } },
             };
 
         private readonly Dictionary<BodyJoint, Transform> jointTransforms = new Dictionary<BodyJoint, Transform>();

--- a/ValheimVRMod/ValheimVRMod.csproj
+++ b/ValheimVRMod/ValheimVRMod.csproj
@@ -13,7 +13,7 @@
     <Deterministic>true</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <CommonDir>C:\Program Files (x86)\Steam\steamapps\common\</CommonDir>
+    <CommonDir>C:\Steam\steamapps\common\</CommonDir>
     <UnityDir>C:\Program Files (x86)\Hub\Editor\2020.3.45f1\</UnityDir>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -60,6 +60,7 @@
   <ItemGroup>
     <PackageReference Include="BepInEx.Core" Version="5.4.21" />
     <PackageReference Include="NDesk.Options" Version="0.2.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="UnityEngine.Modules" Version="2020.3.45" />
     <PackageReference Include="ValheimGameLibz" Version="0.221.12" />
 	<PackageReference Include="Bhaptics.Tac" Version="1.4.16" />
@@ -82,53 +83,47 @@
     </Reference>
     <Reference Include="Unity.XR.Management, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Unity\build\ValheimVR_Data\Managed\Unity.XR.Management.dll</HintPath>
+      <HintPath>$(CommonDir)Valheim\valheim_Data\Managed\Unity.XR.Management.dll</HintPath>
     </Reference>
     <Reference Include="Unity.XR.OpenVR, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Unity\build\ValheimVR_Data\Managed\Unity.XR.OpenVR.dll</HintPath>
+      <HintPath>$(CommonDir)Valheim\valheim_Data\Managed\Unity.XR.OpenVR.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.SpatialTracking">
-      <HintPath>..\Unity\build\ValheimVR_Data\Managed\UnityEngine.SpatialTracking.dll</HintPath>
+      <HintPath>$(CommonDir)Valheim\valheim_Data\Managed\UnityEngine.SpatialTracking.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Unity\build\ValheimVR_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <HintPath>$(CommonDir)Valheim\valheim_Data\Managed\UnityEngine.UI.dll</HintPath>
     </Reference>
     <Reference Include="final_ik.dll">
-      <HintPath>..\Unity\build\ValheimVR_Data\Managed\final_ik.dll</HintPath>
+      <HintPath>$(CommonDir)Valheim\valheim_Data\Managed\final_ik.dll</HintPath>
     </Reference>
     <Reference Include="root_motion_demo_assets">
-      <HintPath>..\Unity\build\ValheimVR_Data\Managed\root_motion_demo_assets.dll</HintPath>
+      <HintPath>$(CommonDir)Valheim\valheim_Data\Managed\root_motion_demo_assets.dll</HintPath>
     </Reference>
     <Reference Include="root_motion_shared">
-      <HintPath>..\Unity\build\ValheimVR_Data\Managed\root_motion_shared.dll</HintPath>
+      <HintPath>$(CommonDir)Valheim\valheim_Data\Managed\root_motion_shared.dll</HintPath>
     </Reference>
     <Reference Include="amplify_occlusion, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Unity\build\ValheimVR_Data\Managed\amplify_occlusion.dll</HintPath>
+      <HintPath>$(CommonDir)Valheim\valheim_Data\Managed\amplify_occlusion.dll</HintPath>
     </Reference>
     <Reference Include="SteamVR, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Unity\build\ValheimVR_Data\Managed\SteamVR.dll</HintPath>
+      <HintPath>$(CommonDir)Valheim\valheim_Data\Managed\SteamVR.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Unity\build\ValheimVR_Data\Managed\Valve.Newtonsoft.Json.dll</HintPath>
+      <HintPath>$(CommonDir)Valheim\valheim_Data\Managed\Valve.Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="SteamVR_Actions, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Unity\build\ValheimVR_Data\Managed\SteamVR_Actions.dll</HintPath>
+      <HintPath>$(CommonDir)Valheim\valheim_Data\Managed\SteamVR_Actions.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="make-release.cmd" EnvironmentVariables="
-	    SOLUTION_DIR=$(SolutionDir);
-	    GAME_DIR=$(CommonDir)Valheim\;   
-	    TARGET_PATH=$(TargetPath);   
-	    TARGET_DIR=$(TargetDir);  
-	    CONFIGURATION_NAME=$(ConfigurationName);    
-	    UNITY_DIR=$(UnityDir);">
+    <Exec Command="make-release.cmd" EnvironmentVariables="&#xD;&#xA;	    SOLUTION_DIR=$(SolutionDir);&#xD;&#xA;	    GAME_DIR=$(CommonDir)Valheim\;   &#xD;&#xA;	    TARGET_PATH=$(TargetPath);   &#xD;&#xA;	    TARGET_DIR=$(TargetDir);  &#xD;&#xA;	    CONFIGURATION_NAME=$(ConfigurationName);    &#xD;&#xA;	    UNITY_DIR=$(UnityDir);">
       <Output TaskParameter="ConsoleOutput" ItemName="OutputOfExec" />
     </Exec>
   </Target>


### PR DESCRIPTION
Changes: Fix chat keyboard instance handling so SteamVR keyboard sessions are idempotent and portal/sign callbacks cannot be replaced by stale chat state. Update staff controls so Ember/fire staff uses trigger-based firing while preserving existing Eitr, equipped-state, secondary-attack, Troll, and trajectory behavior. Align the magic reticle origin with the calculated staff tip without changing aim direction. Verification: dotnet build ValheimVRMod.sln -c Debug succeeded. Existing warning: missing CppCoreCheckRules.ruleset.