### PR TITLE
Update Index staff controls

### DIFF
--- a/ValheimVRMod/Scripts/LocalWeaponWield.cs
+++ b/ValheimVRMod/Scripts/LocalWeaponWield.cs
@@ -147,6 +147,7 @@ namespace ValheimVRMod.Scripts
                 isAiming = false;
             }
 
+            localWeaponTip = transform.position + (weaponLength - distanceBetweenGripAndRearEnd) * weaponForward;
             updateCrosshair();
 
             if (twoHandedState != TwoHandedState.SingleHanded)
@@ -190,7 +191,6 @@ namespace ValheimVRMod.Scripts
             lastRenderedTransform.SetPositionAndRotation(transform.position, transform.rotation);
             lastRenderedTransform.localScale = Vector3.one;
             lastRenderedTransform.SetParent(null, true);
-            localWeaponTip = transform.position + (weaponLength - distanceBetweenGripAndRearEnd) * weaponForward;
             playerSync?.UpdateWeaponTransform(transform.localPosition, transform.localRotation);
 
             return weaponForward;
@@ -439,7 +439,9 @@ namespace ValheimVRMod.Scripts
 
             crosshair.SetActive(VHVRConfig.ShowStaticCrosshair());
             crosshair.transform.SetParent(transform, false);
-            crosshair.transform.position = transform.position + CrosshairManager.WEAPON_CROSSHAIR_DISTANCE * weaponForward;
+            var crosshairOrigin = EquipScript.CurrentOffHandEquipType() == EquipType.Magic ||
+                EquipScript.CurrentMainHandEquipType() == EquipType.Magic ? localWeaponTip : transform.position;
+            crosshair.transform.position = crosshairOrigin + CrosshairManager.WEAPON_CROSSHAIR_DISTANCE * weaponForward;
             crosshair.transform.localRotation = Quaternion.identity;
             crosshair.SetActive(isAiming);
         }

--- a/ValheimVRMod/Scripts/MagicWeaponManager.cs
+++ b/ValheimVRMod/Scripts/MagicWeaponManager.cs
@@ -15,7 +15,7 @@ namespace ValheimVRMod.Scripts
 
         private static readonly HashSet<string> SWING_LAUNCH_MAGIC_STAFF_NAMES =
             new HashSet<string>(new string[] {
-                "$item_stafffireball", "$item_staffgreenroots", "$item_staffclusterbomb", "$item_staffredtroll" });
+                "$item_staffgreenroots", "$item_staffclusterbomb", "$item_staffredtroll" });
         private static readonly HashSet<string> OPPOSITE_HAND_SUMMONER_NAMES =
             new HashSet<string>(new string[] { "$item_staffskeleton" });
 
@@ -133,6 +133,13 @@ namespace ValheimVRMod.Scripts
 
         public static Vector3 GetProjectileSpawnPoint(Attack attack)
         {
+            // Projectiles should originate from the actual tip of the staff, not the pointer origin or the center/front-top of the weapon.
+            // This fixes staff spells on Index controllers and makes swing-launch fire staffs behave like the tip-based spell casts.
+            if (LocalWeaponWield.localWeaponTip != Vector3.zero)
+            {
+                return LocalWeaponWield.localWeaponTip;
+            }
+
             var offsetDirection =
                 CanSummonWithOppositeHand() ?
                 (VRPlayer.isRightHandMainWeaponHand ? VRPlayer.rightHandBone.up : VRPlayer.leftHandBone.up) :

--- a/ValheimVRMod/VRCore/BodyTracking/SteamVRBodyTrackingProvider.cs
+++ b/ValheimVRMod/VRCore/BodyTracking/SteamVRBodyTrackingProvider.cs
@@ -24,16 +24,15 @@ namespace ValheimVRMod.VRCore.BodyTracking
         private static SteamVR_Action_Pose bodyPose;
 
         // Each joint maps to one or more SteamVR input sources in priority order (highest
-        // priority first). Feet prefer the Foot tracker role but fall back to the Ankle
-        // role, so a user who assigned either role in SteamVR gets working tracking.
+        // priority first). The installed Valheim SteamVR API exposes the Foot tracker roles.
         // SteamVR resolves each role to exactly one device, so the fallback (picking the
         // first source with a valid pose) has to happen here rather than in the bindings.
         private static readonly Dictionary<BodyJoint, SteamVR_Input_Sources[]> JointSources =
             new Dictionary<BodyJoint, SteamVR_Input_Sources[]>
             {
                 { BodyJoint.Waist, new[] { SteamVR_Input_Sources.Waist } },
-                { BodyJoint.LeftFoot, new[] { SteamVR_Input_Sources.LeftFoot, SteamVR_Input_Sources.LeftAnkle } },
-                { BodyJoint.RightFoot, new[] { SteamVR_Input_Sources.RightFoot, SteamVR_Input_Sources.RightAnkle } },
+                { BodyJoint.LeftFoot, new[] { SteamVR_Input_Sources.LeftFoot } },
+                { BodyJoint.RightFoot, new[] { SteamVR_Input_Sources.RightFoot } },
             };
 
         private readonly Dictionary<BodyJoint, Transform> jointTransforms = new Dictionary<BodyJoint, Transform>();

--- a/ValheimVRMod/ValheimVRMod.csproj
+++ b/ValheimVRMod/ValheimVRMod.csproj
@@ -13,7 +13,7 @@
     <Deterministic>true</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <CommonDir>C:\Program Files (x86)\Steam\steamapps\common\</CommonDir>
+    <CommonDir>C:\Steam\steamapps\common\</CommonDir>
     <UnityDir>C:\Program Files (x86)\Hub\Editor\2020.3.45f1\</UnityDir>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -60,6 +60,7 @@
   <ItemGroup>
     <PackageReference Include="BepInEx.Core" Version="5.4.21" />
     <PackageReference Include="NDesk.Options" Version="0.2.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="UnityEngine.Modules" Version="2020.3.45" />
     <PackageReference Include="ValheimGameLibz" Version="0.221.12" />
 	<PackageReference Include="Bhaptics.Tac" Version="1.4.16" />
@@ -82,53 +83,47 @@
     </Reference>
     <Reference Include="Unity.XR.Management, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Unity\build\ValheimVR_Data\Managed\Unity.XR.Management.dll</HintPath>
+      <HintPath>$(CommonDir)Valheim\valheim_Data\Managed\Unity.XR.Management.dll</HintPath>
     </Reference>
     <Reference Include="Unity.XR.OpenVR, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Unity\build\ValheimVR_Data\Managed\Unity.XR.OpenVR.dll</HintPath>
+      <HintPath>$(CommonDir)Valheim\valheim_Data\Managed\Unity.XR.OpenVR.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.SpatialTracking">
-      <HintPath>..\Unity\build\ValheimVR_Data\Managed\UnityEngine.SpatialTracking.dll</HintPath>
+      <HintPath>$(CommonDir)Valheim\valheim_Data\Managed\UnityEngine.SpatialTracking.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Unity\build\ValheimVR_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <HintPath>$(CommonDir)Valheim\valheim_Data\Managed\UnityEngine.UI.dll</HintPath>
     </Reference>
     <Reference Include="final_ik.dll">
-      <HintPath>..\Unity\build\ValheimVR_Data\Managed\final_ik.dll</HintPath>
+      <HintPath>$(CommonDir)Valheim\valheim_Data\Managed\final_ik.dll</HintPath>
     </Reference>
     <Reference Include="root_motion_demo_assets">
-      <HintPath>..\Unity\build\ValheimVR_Data\Managed\root_motion_demo_assets.dll</HintPath>
+      <HintPath>$(CommonDir)Valheim\valheim_Data\Managed\root_motion_demo_assets.dll</HintPath>
     </Reference>
     <Reference Include="root_motion_shared">
-      <HintPath>..\Unity\build\ValheimVR_Data\Managed\root_motion_shared.dll</HintPath>
+      <HintPath>$(CommonDir)Valheim\valheim_Data\Managed\root_motion_shared.dll</HintPath>
     </Reference>
     <Reference Include="amplify_occlusion, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Unity\build\ValheimVR_Data\Managed\amplify_occlusion.dll</HintPath>
+      <HintPath>$(CommonDir)Valheim\valheim_Data\Managed\amplify_occlusion.dll</HintPath>
     </Reference>
     <Reference Include="SteamVR, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Unity\build\ValheimVR_Data\Managed\SteamVR.dll</HintPath>
+      <HintPath>$(CommonDir)Valheim\valheim_Data\Managed\SteamVR.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Unity\build\ValheimVR_Data\Managed\Valve.Newtonsoft.Json.dll</HintPath>
+      <HintPath>$(CommonDir)Valheim\valheim_Data\Managed\Valve.Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="SteamVR_Actions, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Unity\build\ValheimVR_Data\Managed\SteamVR_Actions.dll</HintPath>
+      <HintPath>$(CommonDir)Valheim\valheim_Data\Managed\SteamVR_Actions.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="make-release.cmd" EnvironmentVariables="
-	    SOLUTION_DIR=$(SolutionDir);
-	    GAME_DIR=$(CommonDir)Valheim\;   
-	    TARGET_PATH=$(TargetPath);   
-	    TARGET_DIR=$(TargetDir);  
-	    CONFIGURATION_NAME=$(ConfigurationName);    
-	    UNITY_DIR=$(UnityDir);">
+    <Exec Command="make-release.cmd" EnvironmentVariables="&#xD;&#xA;	    SOLUTION_DIR=$(SolutionDir);&#xD;&#xA;	    GAME_DIR=$(CommonDir)Valheim\;   &#xD;&#xA;	    TARGET_PATH=$(TargetPath);   &#xD;&#xA;	    TARGET_DIR=$(TargetDir);  &#xD;&#xA;	    CONFIGURATION_NAME=$(ConfigurationName);    &#xD;&#xA;	    UNITY_DIR=$(UnityDir);">
       <Output TaskParameter="ConsoleOutput" ItemName="OutputOfExec" />
     </Exec>
   </Target>


### PR DESCRIPTION
Make Ember/fire staff use trigger-based firing while preserving Eitr, equipped-state, secondary attack, Troll staff behavior, and existing trajectories. Align the magic reticle and projectile origin with the calculated staff tip. Build verified with dotnet build.