### PR TITLE
Valheim 1.0 (Unity 6) support  (slopcoded via slopus 5)

### DIFF
--- a/ValheimVRMod/Patches/ControlPatches.cs
+++ b/ValheimVRMod/Patches/ControlPatches.cs
@@ -202,6 +202,22 @@ namespace ValheimVRMod.Patches {
     {
         private static MethodInfo IsGamepadActive =
              AccessTools.Method(typeof(ZInput), nameof(ZInput.IsGamepadActive));
+        private static MethodInfo IsMouseActive =
+             AccessTools.Method(typeof(ZInput), nameof(ZInput.IsMouseActive));
+
+        // VHVR feeds the laser pointer through a simulated mouse, so ZInput reports the mouse as
+        // active and Valheim 1.0's LateUpdate takes the mouse look branch, which has no delta and
+        // skips the gamepad branch entirely. Reporting the mouse as inactive here routes camera
+        // look through GetJoyRightStickX/Y, which is where the VR stick values are injected.
+        private static bool IsMouseActivePatched()
+        {
+            if (VHVRConfig.NonVrPlayer() || !VHVRConfig.UseVrControls())
+            {
+                return ZInput.IsMouseActive();
+            }
+
+            return false;
+        }
 
         private static bool IsGamepadActivePatched()
         {
@@ -218,12 +234,26 @@ namespace ValheimVRMod.Patches {
         {
             var original = new List<CodeInstruction>(instructions);
             var patched = new List<CodeInstruction>();
+            // Valheim 1.0 opens LateUpdate with an early return that fires when an input delay is
+            // pending and a gamepad is active. Pretending the gamepad is active there would skip the
+            // rest of the method, camera look included, so only the gate of the look section is
+            // replaced. That section is the one reached via the ZInput.IsMouseActive() check.
+            var reachedLookSection = false;
             foreach (var instruction in original)
             {
-                if (instruction.Calls(IsGamepadActive))
+                if (instruction.Calls(IsMouseActive))
                 {
+                    reachedLookSection = true;
                     patched.Add(
-                        CodeInstruction.Call(typeof(PlayerController_LateUpdate_Patch), nameof(IsGamepadActivePatched)));
+                        instruction.ReplaceCallWith(typeof(PlayerController_LateUpdate_Patch), nameof(IsMouseActivePatched)));
+                    continue;
+                }
+
+                if (reachedLookSection && instruction.Calls(IsGamepadActive))
+                {
+                    // In Valheim 1.0 this call is a branch target, so its metadata has to survive the rewrite.
+                    patched.Add(
+                        instruction.ReplaceCallWith(typeof(PlayerController_LateUpdate_Patch), nameof(IsGamepadActivePatched)));
                 }
                 else
                 {
@@ -406,17 +436,17 @@ namespace ValheimVRMod.Patches {
                 // of moving the map around since that will be done with
                 // simulated mouse cursor click and drag via laser pointer.
                 if (instruction.Calls(getJoyLeftStickX)) {
-                    patched.Add(CodeInstruction.Call(typeof(Minimap_UpdateMap_Patch),
+                    patched.Add(instruction.ReplaceCallWith(typeof(Minimap_UpdateMap_Patch),
                         nameof(getJoyLeftStickXPatched), new[] { typeof(bool) }));
                 }
                 else if (instruction.Calls(getJoyLeftStickY)) {
-                    patched.Add(CodeInstruction.Call(typeof(Minimap_UpdateMap_Patch),
+                    patched.Add(instruction.ReplaceCallWith(typeof(Minimap_UpdateMap_Patch),
                         nameof(getJoyLeftStickYPatched), new[] { typeof(bool) }));
                 }
                 else if (instruction.Calls(GetButtonPatchUtils.GetButtonDownOriginal))
                 {
                     // Necessary for map zoom in case ZInput prefix/postfix stops working
-                    patched.Add(CodeInstruction.Call(typeof(GetButtonPatchUtils),
+                    patched.Add(instruction.ReplaceCallWith(typeof(GetButtonPatchUtils),
                         nameof(GetButtonPatchUtils.GetButtonDownPatched), new[] { typeof(string) }));
                 }
                 else {
@@ -516,13 +546,13 @@ namespace ValheimVRMod.Patches {
                 if (original[i + 1].Calls(GetButtonPatchUtils.GetButtonDownOriginal))
                 {
                     patched.Add(
-                        CodeInstruction.Call(
+                        original[i + 1].ReplaceCallWith(
                             typeof(Player_UpdatePlacement_BuildInputPatch),
                             nameof(ShouldTriggerBuildPlacement)));
                 }
                 else if (original[i + 1].Calls(GetButtonPatchUtils.GetButtonUpOriginal)) {
                     patched.Add(
-                        CodeInstruction.Call(
+                        original[i + 1].ReplaceCallWith(
                             typeof(GetButtonPatchUtils),
                             nameof(GetButtonPatchUtils.GetButtonUpPatched)));
                 }
@@ -924,9 +954,8 @@ namespace ValheimVRMod.Patches {
                 {
                     // Do not let the player unmount unless jumping.
                     // This prevents interactions such as range weapon attack from unmounting when riding.
-                    var changed = CodeInstruction.Call(typeof(MountedAttackUtils), nameof(MountedAttackUtils.UnmountIfJumping));
-                    changed.labels = original[i].labels;
-                    original[i] = changed;
+                    // Carries over exception blocks as well as labels.
+                    original[i] = original[i].ReplaceCallWith(typeof(MountedAttackUtils), nameof(MountedAttackUtils.UnmountIfJumping));
                 }
             }
             return original;
@@ -949,9 +978,8 @@ namespace ValheimVRMod.Patches {
                 {
                     // Do not let the player unmount unless jumping.
                     // This prevents interactions such as range weapon attack from unmounting when riding.
-                    var changed = CodeInstruction.Call(typeof(MountedAttackUtils), nameof(MountedAttackUtils.UnmountIfJumping));
-                    changed.labels = original[i].labels;
-                    original[i] = changed;
+                    // Carries over exception blocks as well as labels.
+                    original[i] = original[i].ReplaceCallWith(typeof(MountedAttackUtils), nameof(MountedAttackUtils.UnmountIfJumping));
                 }
             }
             return original;
@@ -967,7 +995,7 @@ namespace ValheimVRMod.Patches {
             {
                 return;
             }
-            __instance.m_splitSlider.gameObject.AddComponent<SliderSelector>();
+            __instance.m_splitDialog.m_splitSlider.gameObject.AddComponent<SliderSelector>();
         }
     }
 
@@ -1024,7 +1052,7 @@ namespace ValheimVRMod.Patches {
     [HarmonyPatch(typeof(InventoryGrid), nameof(InventoryGrid.GetHoveredElement))]
     static class InventoryGrid_GetHoveredElement_Patch
     {
-        static bool Prefix(InventoryGrid __instance, ref InventoryGrid.Element __result)
+        static bool Prefix(InventoryGrid __instance, ref InventoryElement __result)
         {
             if (VHVRConfig.NonVrPlayer())
             {
@@ -1034,10 +1062,10 @@ namespace ValheimVRMod.Patches {
             // so this resolves the same element the EventSystem hovers and the tooltip patch accepts.
             var canvas = __instance.GetComponentInParent<Canvas>();
             var camera = canvas == null ? null : canvas.rootCanvas.worldCamera;
-            foreach (InventoryGrid.Element element in __instance.m_elements)
+            foreach (InventoryElement element in __instance.m_elements)
             {
                 if (RectTransformUtility.RectangleContainsScreenPoint(
-                    element.m_go.transform as RectTransform, SoftwareCursor.simulatedMousePosition, camera))
+                    element.GetElementRectTransform(), SoftwareCursor.simulatedMousePosition, camera))
                 {
                     __result = element;
                     return false;
@@ -1066,7 +1094,7 @@ namespace ValheimVRMod.Patches {
         }
     }
 
-    // This patch hijacks the right click input on minimap to enable
+    // This patch hijacks the pin removal input on minimap to enable
     // adding map pings. With a normal right click, the default behavior
     // exists where a map pin will be removed. If the click modifier
     // is held down, then instead of removing a pin, a map ping will
@@ -1075,7 +1103,9 @@ namespace ValheimVRMod.Patches {
     // between laser pointers and normal controls, things can end up being
     // extra complex when we need to use a new button. Since we already have
     // the modifier, this is simpler).
-    [HarmonyPatch(typeof(Minimap), nameof(Minimap.OnMapRightClick))]
+    // Valheim 1.0 replaced Minimap.OnMapRightClick with RemovePinUnderPointer, which is what the
+    // right click on the map now invokes.
+    [HarmonyPatch(typeof(Minimap), nameof(Minimap.RemovePinUnderPointer))]
     class MinimapPingPatch
     {
         static bool Prefix(Minimap __instance)

--- a/ValheimVRMod/Patches/EyeRotationPatch.cs
+++ b/ValheimVRMod/Patches/EyeRotationPatch.cs
@@ -429,7 +429,7 @@ namespace ValheimVRMod.Patches
                 foreach (var instruction in original)
                 {
                     if (instruction.Calls(MenuIsVisibleCall))
-                        patched.Add(CodeInstruction.Call(typeof(Game_UpdatePause_Patch), nameof(Game_UpdatePause_Patch.Nope)));
+                        patched.Add(instruction.ReplaceCallWith(typeof(Game_UpdatePause_Patch), nameof(Game_UpdatePause_Patch.Nope)));
                     else
                         patched.Add(instruction);
                 }

--- a/ValheimVRMod/Patches/FixPatches.cs
+++ b/ValheimVRMod/Patches/FixPatches.cs
@@ -7,6 +7,40 @@ using Valve.VR.InteractionSystem;
 using Valheim.SettingsGui;
 
 namespace ValheimVRMod.Patches {
+
+    // Valheim 1.0 added CinematicsManager, whose camera renders straight to the screen with every
+    // layer in its culling mask, including the UI layer. In VR that camera drew the world space GUI
+    // canvas a second time from its own transform, which is why the main menu appeared twice while
+    // the startup cinematic was still active. The intro video itself also does not composite into a
+    // headset, so it is not started in VR.
+    [HarmonyPatch(typeof(CinematicsManager), "Awake")]
+    class CinematicsManager_Awake_Patch
+    {
+        static void Postfix(CinematicsManager __instance)
+        {
+            if (VHVRConfig.NonVrPlayer())
+            {
+                return;
+            }
+
+            __instance.m_introOnStartup = false;
+            __instance.m_introOnNewWorld = false;
+
+            if (__instance.m_camera == null)
+            {
+                return;
+            }
+
+            // Anything VHVR renders through its own dedicated cameras must stay off this one.
+            var mask = __instance.m_camera.cullingMask;
+            mask &= ~(1 << LayerMask.NameToLayer("UI"));
+            mask &= ~(1 << LayerUtils.getUiPanelLayer());
+            mask &= ~(1 << LayerUtils.getHandsLayer());
+            mask &= ~(1 << LayerUtils.getWorldspaceUiLayer());
+            __instance.m_camera.cullingMask = mask;
+        }
+    }
+
     [HarmonyPatch(typeof(Hand), "FixedUpdate")]
     class PatchDebug {
 

--- a/ValheimVRMod/Patches/InteractionPatches.cs
+++ b/ValheimVRMod/Patches/InteractionPatches.cs
@@ -228,13 +228,13 @@ namespace ValheimVRMod.Patches
                     if (gameCameraCount == 0)
                     {
                         LogUtils.LogDebug("Patching FindHoverObject Raycast Starting Position");
-                        patched.Add(CodeInstruction.Call(typeof(KBandMouse_FindHoverObjectPatch), nameof(GetVRCameraPosition)));
+                        patched.Add(CodeInstruction.Call(typeof(KBandMouse_FindHoverObjectPatch), nameof(GetVRCameraPosition)).KeepMetadataOf(instruction));
                         i++;
                         i++;
                     } else if (gameCameraCount == 1)
                     {
                         LogUtils.LogDebug("Patching FindHoverObject Raycast Direction");
-                        patched.Add(CodeInstruction.Call(typeof(KBandMouse_FindHoverObjectPatch), nameof(GetVRCameraForward)));
+                        patched.Add(CodeInstruction.Call(typeof(KBandMouse_FindHoverObjectPatch), nameof(GetVRCameraForward)).KeepMetadataOf(instruction));
                         i++;
                         i++;
                     } else

--- a/ValheimVRMod/Patches/Misc.cs
+++ b/ValheimVRMod/Patches/Misc.cs
@@ -159,9 +159,8 @@ namespace ValheimVRMod.Patches
             {
                 if (original[i].Calls(AccessTools.Method(typeof(Application), "set_targetFrameRate", new[] { typeof(Int32) })))
                 {
-                    var changed = CodeInstruction.Call(typeof(Application_FrameRate_Patch), nameof(Nop), new[] { typeof(Int32) });
-                    changed.labels = original[i].labels;
-                    original[i] = changed;
+                    // Carries over exception blocks as well as labels.
+                    original[i] = original[i].ReplaceCallWith(typeof(Application_FrameRate_Patch), nameof(Nop), new[] { typeof(Int32) });
                 }
             }
             return original;
@@ -198,11 +197,11 @@ namespace ValheimVRMod.Patches
                 }
                 if (instruction.Calls(rotateMethod) && original[i - 1].opcode == OpCodes.Mul)
                 {
-                    patched.Add(CodeInstruction.Call(typeof(Prevent_Pause_Character_Spin_Patch), nameof(Prevent_Pause_Character_Spin_Patch.FakeRotate)));
+                    patched.Add(instruction.ReplaceCallWith(typeof(Prevent_Pause_Character_Spin_Patch), nameof(Prevent_Pause_Character_Spin_Patch.FakeRotate)));
                 }
                 else if (instruction.Calls(setLookDirMethod))
                 {
-                    patched.Add(CodeInstruction.Call(typeof(Prevent_Pause_Character_Spin_Patch), nameof(Prevent_Pause_Character_Spin_Patch.FakeSetLookDir)));
+                    patched.Add(instruction.ReplaceCallWith(typeof(Prevent_Pause_Character_Spin_Patch), nameof(Prevent_Pause_Character_Spin_Patch.FakeSetLookDir)));
                 }
                 else
                 {

--- a/ValheimVRMod/Patches/PostProcessingPatches.cs
+++ b/ValheimVRMod/Patches/PostProcessingPatches.cs
@@ -18,6 +18,18 @@ namespace ValheimVRMod.Patches
     [HarmonyPatch]
     public class PostProcessingPatches
     {
+        // Valheim 1.0 made CameraEffects.Awake() call ApplySettings() straight away, and SetSSAO
+        // dereferences the serialized m_amplifyOcclusion field. VHVR adds CameraEffects to the VR
+        // camera at runtime, where that field is still null while Awake runs, and the resulting
+        // NullReferenceException aborted the whole VR camera setup - which left the world space UI
+        // camera uncreated and the post processing effects unconfigured.
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(CameraEffects), nameof(CameraEffects.SetSSAO))]
+        static bool PrefixCameraEffectsSetSSAO(CameraEffects __instance)
+        {
+            return __instance.m_amplifyOcclusion != null;
+        }
+
         [HarmonyPostfix]
         [HarmonyPatch(typeof(PostProcessingBehaviour), "OnEnable")]
         static void PostfixPostProcessingOnEnable(PostProcessingBehaviour __instance, TaaComponent ___m_Taa, Dictionary<PostProcessingComponentBase, bool> ___m_ComponentStates, List<PostProcessingComponentBase> ___m_Components)
@@ -73,31 +85,43 @@ namespace ValheimVRMod.Patches
                 {
                     Debug.Log("Patched TAA reference");
                     var lastInstuction = patched[patched.Count - 1];
+                    CodeInstruction removed = null;
                     if (lastInstuction != null && lastInstuction.opcode == OpCodes.Ldarg_0)
+                    {
+                        removed = lastInstuction;
                         patched.RemoveAt(patched.Count - 1);
-                    patched.Add(new CodeInstruction(OpCodes.Ldsfld, AccessTools.Field(typeof(VRTaaComponent), nameof(VRTaaComponent.PostProcessingExtension))));
+                    }
+                    var loadExtensionTable = new CodeInstruction(OpCodes.Ldsfld, AccessTools.Field(typeof(VRTaaComponent), nameof(VRTaaComponent.PostProcessingExtension)));
+                    // Anything branching to the instructions being replaced has to land on the head of the
+                    // replacement sequence instead, otherwise Harmony fails to emit the method.
+                    if (removed != null)
+                    {
+                        removed.MoveMetadataTo(loadExtensionTable);
+                    }
+                    instruction.MoveMetadataTo(loadExtensionTable);
+                    patched.Add(loadExtensionTable);
                     patched.Add(new CodeInstruction(OpCodes.Ldarg_0));
                     patched.Add(new CodeInstruction(OpCodes.Callvirt, AccessTools.Method(typeof(ConditionalWeakTable<PostProcessingBehaviour, VRTaaComponent>), nameof(ConditionalWeakTable<PostProcessingBehaviour, VRTaaComponent>.GetOrCreateValue), new Type[] { typeof(PostProcessingBehaviour)})));
                 }
                 else if (instruction.Calls(CallsTaaSetProjectionMatrix))
                 {
                     Debug.Log("Patched TAA SetProjectionMatrix");
-                    patched.Add(new CodeInstruction(instruction.opcode, AccessTools.Method(typeof(VRTaaComponent), nameof(VRTaaComponent.ConfigureStereoMonoProjectionMatrices), new Type[] { typeof(Func<Vector2, Matrix4x4>) })));
+                    patched.Add(new CodeInstruction(instruction.opcode, AccessTools.Method(typeof(VRTaaComponent), nameof(VRTaaComponent.ConfigureStereoMonoProjectionMatrices), new Type[] { typeof(Func<Vector2, Matrix4x4>) })).KeepMetadataOf(instruction));
                 }
                 else if (instruction.Calls(CallsTaaRender))
                 {
                     Debug.Log("Patched TAA Render");
-                    patched.Add(new CodeInstruction(instruction.opcode, AccessTools.Method(typeof(VRTaaComponent), nameof(VRTaaComponent.Render), new Type[] { typeof(RenderTexture), typeof(RenderTexture) })));
+                    patched.Add(new CodeInstruction(instruction.opcode, AccessTools.Method(typeof(VRTaaComponent), nameof(VRTaaComponent.Render), new Type[] { typeof(RenderTexture), typeof(RenderTexture) })).KeepMetadataOf(instruction));
                 }
                 else if (instruction.Calls(CallsTaaGetJitterVector))
                 {
                     Debug.Log("Patched TAA GetJitterVector");
-                    patched.Add(new CodeInstruction(instruction.opcode, AccessTools.PropertyGetter(typeof(VRTaaComponent), nameof(VRTaaComponent.jitterVector))));
+                    patched.Add(new CodeInstruction(instruction.opcode, AccessTools.PropertyGetter(typeof(VRTaaComponent), nameof(VRTaaComponent.jitterVector))).KeepMetadataOf(instruction));
                 }
                 else if (instruction.Calls(CallsTaaResetHistory))
                 {
                     Debug.Log("Patched TAA ResetHistory");
-                    patched.Add(new CodeInstruction(instruction.opcode, AccessTools.Method(typeof(VRTaaComponent), nameof(VRTaaComponent.ResetHistory))));
+                    patched.Add(new CodeInstruction(instruction.opcode, AccessTools.Method(typeof(VRTaaComponent), nameof(VRTaaComponent.ResetHistory))).KeepMetadataOf(instruction));
                 }
                 else
                 {

--- a/ValheimVRMod/Patches/TextInputPatches.cs
+++ b/ValheimVRMod/Patches/TextInputPatches.cs
@@ -102,7 +102,7 @@ namespace ValheimVRMod.Patches {
 
         private static void OnClose()
         {
-            Minimap.m_instance.m_nameInput.OnInputSubmit.Invoke(Minimap.m_instance.m_nameInput.text);
+            Minimap.instance.m_nameInput.OnInputSubmit.Invoke(Minimap.instance.m_nameInput.text);
         }
     }
 

--- a/ValheimVRMod/Patches/UIPatches.cs
+++ b/ValheimVRMod/Patches/UIPatches.cs
@@ -43,7 +43,11 @@ namespace ValheimVRMod.Patches
                 if (instruction.Calls(setParentMethod))
                 {
                     // Push "false" onto evaluation stack
-                    patched.Add(new CodeInstruction(OpCodes.Ldc_I4_0));
+                    var pushFalse = new CodeInstruction(OpCodes.Ldc_I4_0);
+                    // The call being replaced may be a branch target, so anything pointing at it has to
+                    // point at the head of the replacement sequence instead.
+                    instruction.MoveMetadataTo(pushFalse);
+                    patched.Add(pushFalse);
                     // Call SetParent method that uses the bool input
                     patched.Add(CodeInstruction.Call(typeof(Transform), "SetParent", new Type[] { typeof(Transform), typeof(bool) }));
                 } else

--- a/ValheimVRMod/Scripts/InterhandItemTransfer.cs
+++ b/ValheimVRMod/Scripts/InterhandItemTransfer.cs
@@ -108,18 +108,20 @@ namespace ValheimVRMod.Scripts
 
             // Force re-equip to apply new handedness
             var rightHash = player.m_visEquipment.m_currentRightItemHash;
+            var rightQuality = player.m_visEquipment.m_currentRightItemQuality;
             if (rightHash != 0)
             {
-                player.m_visEquipment.SetRightHandEquipped(0);
-                player.m_visEquipment.SetRightHandEquipped(rightHash);
+                player.m_visEquipment.SetRightHandEquipped(0, 0);
+                player.m_visEquipment.SetRightHandEquipped(rightHash, rightQuality);
             }
 
             var leftHash = player.m_visEquipment.m_currentLeftItemHash;
             var leftVariant = player.m_visEquipment.m_currentLeftItemVariant;
+            var leftQuality = player.m_visEquipment.m_currentLeftItemQuality;
             if (leftHash != 0)
             {
-                player.m_visEquipment.SetLeftHandEquipped(0, 0);
-                player.m_visEquipment.SetLeftHandEquipped(leftHash, leftVariant);
+                player.m_visEquipment.SetLeftHandEquipped(0, 0, 0);
+                player.m_visEquipment.SetLeftHandEquipped(leftHash, leftVariant, leftQuality);
             }
 
             if (isTransferringParryingKnife)

--- a/ValheimVRMod/Scripts/VRPlayerSync.cs
+++ b/ValheimVRMod/Scripts/VRPlayerSync.cs
@@ -341,6 +341,7 @@ namespace ValheimVRMod.Scripts {
             // Force re-equip to trigger a patch with the updated isLeftHanded.
             var mainHandItem = player.m_visEquipment.m_rightItemInstance;
             var mainHandItemHash = player.m_visEquipment.m_currentRightItemHash;
+            var mainHandItemQuality = player.m_visEquipment.m_currentRightItemQuality;
             if (mainHandItem != null && mainHandItemHash != 0)
             {
                 if (isLeftHanded ?
@@ -348,8 +349,8 @@ namespace ValheimVRMod.Scripts {
                     mainHandItem.transform.parent == player.m_visEquipment.m_leftHand)
                 {
                     LogUtils.LogDebug("Switching main hand item to the other hand");
-                    player.m_visEquipment.SetRightHandEquipped(0);
-                    player.m_visEquipment.SetRightHandEquipped(mainHandItemHash);
+                    player.m_visEquipment.SetRightHandEquipped(0, 0);
+                    player.m_visEquipment.SetRightHandEquipped(mainHandItemHash, mainHandItemQuality);
                 }
             }
 
@@ -363,8 +364,9 @@ namespace ValheimVRMod.Scripts {
                 {
                     LogUtils.LogDebug("Switching secondary hand item to right hand");
                     var variant = player.m_visEquipment.m_currentLeftItemVariant;
-                    player.m_visEquipment.SetLeftHandEquipped(0, 0);
-                    player.m_visEquipment.SetLeftHandEquipped(offHandItemHash, variant);
+                    var quality = player.m_visEquipment.m_currentLeftItemQuality;
+                    player.m_visEquipment.SetLeftHandEquipped(0, 0, 0);
+                    player.m_visEquipment.SetLeftHandEquipped(offHandItemHash, variant, quality);
                 }
             }
         }

--- a/ValheimVRMod/Utilities/GetButtonPatchUtils.cs
+++ b/ValheimVRMod/Utilities/GetButtonPatchUtils.cs
@@ -69,10 +69,12 @@ namespace ValheimVRMod.Utilities
             var patched = new List<CodeInstruction>();
             foreach (var instruction in original)
             {
+                // These calls can be branch targets or sit inside exception blocks, so replace them in
+                // place instead of emitting fresh instructions that would drop that metadata.
                 if (instruction.Calls(GetButtonOriginal))
                 {
                     patched.Add(
-                        CodeInstruction.Call(
+                        instruction.ReplaceCallWith(
                             typeof(GetButtonPatchUtils),
                             nameof(GetButtonPatched),
                             new[] { typeof(string) }));
@@ -80,7 +82,7 @@ namespace ValheimVRMod.Utilities
                 else if (instruction.Calls(GetButtonDownOriginal))
                 {
                     patched.Add(
-                        CodeInstruction.Call(
+                        instruction.ReplaceCallWith(
                             typeof(GetButtonPatchUtils),
                             nameof(GetButtonDownPatched),
                             new[] { typeof(string) }));
@@ -88,7 +90,7 @@ namespace ValheimVRMod.Utilities
                 else if (instruction.Calls(GetButtonUpOriginal))
                 {
                     patched.Add(
-                        CodeInstruction.Call(
+                        instruction.ReplaceCallWith(
                             typeof(GetButtonPatchUtils),
                             nameof(GetButtonUpPatched),
                             new[] { typeof(string) }));

--- a/ValheimVRMod/Utilities/TranspilerUtils.cs
+++ b/ValheimVRMod/Utilities/TranspilerUtils.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+using HarmonyLib;
+
+namespace ValheimVRMod.Utilities
+{
+    // Helpers for rewriting IL without losing the metadata attached to the instructions being replaced.
+    //
+    // Creating a fresh CodeInstruction (e. g. via CodeInstruction.Call()) and putting it where an existing
+    // instruction used to be silently drops that instruction's branch labels and exception block markers.
+    // If anything branched to the replaced instruction, Harmony then fails to emit the method with
+    // "ArgumentException: Label #N is not marked", which aborts patching and takes the whole mod down with it.
+    // Valheim 1.0 recompiled the game assemblies, so calls we rewrite are now branch targets in methods where
+    // they previously were not, which is why this has to be handled everywhere rather than case by case.
+    public static class TranspilerUtils
+    {
+        // Copies the labels and exception blocks of source onto target and returns target, so that a replacement
+        // instruction stays a valid branch target and stays inside the same try/catch/finally region.
+        // Use this when the replacement instruction is built by hand.
+        public static CodeInstruction KeepMetadataOf(this CodeInstruction target, CodeInstruction source)
+        {
+            target.labels.AddRange(source.labels);
+            target.blocks.AddRange(source.blocks);
+            return target;
+        }
+
+        // Drop-in replacement for CodeInstruction.Call() for the case where the emitted instruction takes the
+        // place of an existing one: emits the same "call <replacement>" that CodeInstruction.Call() would, but
+        // keeps the labels and exception blocks of the instruction being replaced.
+        public static CodeInstruction ReplaceCallWith(this CodeInstruction instruction, MethodInfo replacement)
+        {
+            if (replacement == null)
+            {
+                throw new ArgumentNullException(nameof(replacement));
+            }
+
+            // OpCodes.Call unconditionally, matching CodeInstruction.Call(), so that swapping a call out never
+            // changes how it is dispatched. Only the labels and blocks are carried over from the original.
+            return new CodeInstruction(OpCodes.Call, replacement).KeepMetadataOf(instruction);
+        }
+
+        // Convenience overload resolving the replacement by declaring type and name.
+        public static CodeInstruction ReplaceCallWith(this CodeInstruction instruction, Type type, string name, Type[] parameters = null)
+        {
+            var replacement = AccessTools.Method(type, name, parameters);
+            if (replacement == null)
+            {
+                throw new MissingMethodException(type.FullName, name);
+            }
+
+            return instruction.ReplaceCallWith(replacement);
+        }
+
+        // Moves the labels and exception blocks off instruction and onto the first instruction of a replacement
+        // sequence, for the cases where one instruction is expanded into several. The original instruction is
+        // left without metadata so that it can be discarded without duplicating labels.
+        public static void MoveMetadataTo(this CodeInstruction instruction, CodeInstruction target)
+        {
+            target.labels.AddRange(instruction.labels);
+            target.blocks.AddRange(instruction.blocks);
+            instruction.labels.Clear();
+            instruction.blocks.Clear();
+        }
+    }
+}

--- a/ValheimVRMod/VRCore/UI/ConfigSettings.cs
+++ b/ValheimVRMod/VRCore/UI/ConfigSettings.cs
@@ -121,8 +121,11 @@ namespace ValheimVRMod.VRCore.UI {
             }
             if (chooserPrefab == null)
             {
-                chooserPrefab = createChooserPrefab(
-                    settingsPrefab.transform.Find("Panel").Find("TabContent").Find("Gamepad").Find("List").Find("InputLayout").gameObject);
+                var chooserSource = findInputLayoutChooser();
+                if (chooserSource != null)
+                {
+                    chooserPrefab = createChooserPrefab(chooserSource);
+                }
             }
             if (transformButtonPrefab == null)
             {
@@ -412,6 +415,55 @@ namespace ValheimVRMod.VRCore.UI {
 
         }
 
+        // Valheim 1.0 rebuilt the settings prefab, so the gamepad tab is no longer a child called
+        // "Gamepad" under TabContent. Locate it by its component instead, which does not depend on
+        // the names of the prefab's children, and search for the chooser element recursively.
+        private static GameObject findInputLayoutChooser()
+        {
+            var gamepadTab = settingsPrefab.GetComponentInChildren<GamepadSettings>(includeInactive: true);
+            var root = gamepadTab != null ? gamepadTab.transform : settingsPrefab.transform;
+            var chooser = findDeepChild(root, "InputLayout");
+            if (chooser == null)
+            {
+                LogUtils.LogWarning(
+                    "Could not find the input layout chooser under \"" + root.name +
+                    "\"; settings that use a value chooser will be skipped. Hierarchy follows:");
+                logHierarchy(root, 0, 3);
+                return null;
+            }
+            return chooser.gameObject;
+        }
+
+        private static Transform findDeepChild(Transform parent, string name)
+        {
+            if (parent.name == name)
+            {
+                return parent;
+            }
+            for (int i = 0; i < parent.childCount; i++)
+            {
+                var found = findDeepChild(parent.GetChild(i), name);
+                if (found != null)
+                {
+                    return found;
+                }
+            }
+            return null;
+        }
+
+        private static void logHierarchy(Transform t, int depth, int maxDepth)
+        {
+            LogUtils.LogWarning(new string(' ', depth * 2) + t.name);
+            if (depth >= maxDepth)
+            {
+                return;
+            }
+            for (int i = 0; i < t.childCount; i++)
+            {
+                logHierarchy(t.GetChild(i), depth + 1, maxDepth);
+            }
+        }
+
         private static GameObject createChooserPrefab(GameObject vanillaPrefab)
         {
             var chooserPrefab = Object.Instantiate(vanillaPrefab);
@@ -453,6 +505,12 @@ namespace ValheimVRMod.VRCore.UI {
 
         private static void createValueList(
             KeyValuePair<string, ConfigEntryBase> configValue, Transform parent, Vector2 pos, Type type, AcceptableValueBase acceptableValues) {
+
+            if (chooserPrefab == null)
+            {
+                LogUtils.LogWarning("No chooser prefab available, skipping setting " + configValue.Key);
+                return;
+            }
 
             var chooserObj = Object.Instantiate(chooserPrefab, parent);
             chooserObj.GetComponent<RectTransform>().anchoredPosition = pos + Vector2.left * 10;

--- a/ValheimVRMod/VRCore/UI/HudElements/MinimapPanelElement.cs
+++ b/ValheimVRMod/VRCore/UI/HudElements/MinimapPanelElement.cs
@@ -82,7 +82,7 @@ namespace ValheimVRMod.VRCore.UI.HudElements
                 _original.mapRoot.SetActive(false);
             }
 
-            if (Minimap.m_instance.m_mode == Minimap.MapMode.Small)
+            if (Minimap.instance.m_mode == Minimap.MapMode.Small)
             {
                 _clone.Root.SetActive(toggledOn);
             }

--- a/ValheimVRMod/VRCore/VRPlayer.cs
+++ b/ValheimVRMod/VRCore/VRPlayer.cs
@@ -567,6 +567,10 @@ namespace ValheimVRMod.VRCore
             }
             var effect = _vrCam.gameObject.GetComponent<AmplifyOcclusionEffect>();
             effect.SampleCount = SampleCountLevel.Medium;
+            // The temporal filter accumulates occlusion across frames. The two eyes are rendered in
+            // sequence, so each one blends in the other's history, which makes fine shadowing (grass
+            // most visibly) drift independently in each eye. The spatial blur keeps the look without it.
+            effect.FilterEnabled = false;
             effect.enabled = VHVRConfig.UseAmplifyOcclusion();
         }
 
@@ -910,8 +914,9 @@ namespace ValheimVRMod.VRCore
             }
             Camera vrCam = CameraUtils.getCamera(CameraUtils.VR_CAMERA);
             CameraUtils.copyCamera(mainCamera, vrCam);
-            maybeCopyPostProcessingEffects(vrCam, mainCamera);
+            // Must run first: Valheim 1.0's CameraEffects wants a reference to the occlusion effect.
             maybeAddAmplifyOcclusion(vrCam);
+            maybeCopyPostProcessingEffects(vrCam, mainCamera);
             // Prevent visibility of the head
             vrCam.nearClipPlane = VHVRConfig.GetNearClipPlane();
             MainCameraFarClipPlane = mainCamera.farClipPlane;
@@ -1814,6 +1819,10 @@ namespace ValheimVRMod.VRCore
                 CopyClassFields(mainCamSunshaft, ref vrCamSunshaft);
             }
             var vrCamEffects = vrCamera.gameObject.AddComponent<CameraEffects>();
+            // m_amplifyOcclusion is deliberately left null here. VHVR owns the occlusion effect on the
+            // VR camera through UpdateAmplifyOcclusionStatus() and its own UseAmplifyOcclusion setting;
+            // wiring the game's CameraEffects to it as well makes both of them fight over enabled,
+            // Downsample and SampleCount, which shows up as screen space artifacts in stereo.
             var mainCamEffects = mainCamera.gameObject.GetComponent<CameraEffects>();
             if (mainCamEffects != null)
             {

--- a/ValheimVRMod/ValheimVRMod.csproj
+++ b/ValheimVRMod/ValheimVRMod.csproj
@@ -13,7 +13,13 @@
     <Deterministic>true</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoStdLib>true</NoStdLib>
+    <!-- Without this the SDK also references the .NET Framework assemblies, whose BCL types
+         then collide with Unity's. -->
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+    <NoConfig>true</NoConfig>
     <CommonDir>C:\Program Files (x86)\Steam\steamapps\common\</CommonDir>
+    <GameManagedDir>$(CommonDir)Valheim\valheim_Data\Managed\</GameManagedDir>
     <UnityDir>C:\Program Files (x86)\Hub\Editor\2020.3.45f1\</UnityDir>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -60,26 +66,18 @@
   <ItemGroup>
     <PackageReference Include="BepInEx.Core" Version="5.4.21" />
     <PackageReference Include="NDesk.Options" Version="0.2.1" />
-    <PackageReference Include="UnityEngine.Modules" Version="2020.3.45" />
-    <PackageReference Include="ValheimGameLibz" Version="0.221.12" />
+
 	<PackageReference Include="Bhaptics.Tac" Version="1.4.16" />
   </ItemGroup>
+  <!-- Valheim 1.0 moved to Unity 6 and no NuGet package tracks its assemblies, so the game
+       assemblies are referenced straight out of the install. publicized_assemblies is produced
+       by Bepinex Publicizer (see README.development.md). -->
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.ValueTuple" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="Unity.InputSystem">
-      <HintPath>$(CommonDir)Valheim\valheim_Data\Managed\Unity.InputSystem.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.TextMeshPro">
-      <HintPath>$(CommonDir)Valheim\valheim_Data\Managed\Unity.TextMeshPro.dll</HintPath>
-    </Reference>
-    <Reference Include="gui_framework, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>$(CommonDir)Valheim\valheim_Data\Managed\gui_framework.dll</HintPath>
-    </Reference>
+    <!-- Publicized game and Unity engine assemblies. -->
+    <Reference Include="$(GameManagedDir)publicized_assemblies\*.dll" Private="false" />
+  </ItemGroup>
+  <ItemGroup>
+
     <Reference Include="Unity.XR.Management, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Unity\build\ValheimVR_Data\Managed\Unity.XR.Management.dll</HintPath>
@@ -88,13 +86,7 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Unity\build\ValheimVR_Data\Managed\Unity.XR.OpenVR.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEngine.SpatialTracking">
-      <HintPath>..\Unity\build\ValheimVR_Data\Managed\UnityEngine.SpatialTracking.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.UI, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Unity\build\ValheimVR_Data\Managed\UnityEngine.UI.dll</HintPath>
-    </Reference>
+
     <Reference Include="final_ik.dll">
       <HintPath>..\Unity\build\ValheimVR_Data\Managed\final_ik.dll</HintPath>
     </Reference>
@@ -104,10 +96,7 @@
     <Reference Include="root_motion_shared">
       <HintPath>..\Unity\build\ValheimVR_Data\Managed\root_motion_shared.dll</HintPath>
     </Reference>
-    <Reference Include="amplify_occlusion, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Unity\build\ValheimVR_Data\Managed\amplify_occlusion.dll</HintPath>
-    </Reference>
+
     <Reference Include="SteamVR, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Unity\build\ValheimVR_Data\Managed\SteamVR.dll</HintPath>
@@ -121,14 +110,39 @@
       <HintPath>..\Unity\build\ValheimVR_Data\Managed\SteamVR_Actions.dll</HintPath>
     </Reference>
   </ItemGroup>
+  <!-- ResolveAssemblyReferences drops any reference to the core library, so Unity's mscorlib is
+       appended to the compiler's reference list directly. Together with NoStdLib this makes the
+       build see Unity 6's BCL (which defines System.Span, used by new Unity API overloads). -->
+  <Target Name="UseUnityCorlib" AfterTargets="ResolveAssemblyReferences">
+    <ItemGroup>
+      <!-- BepInEx.Core pulls in Microsoft.NETFramework.ReferenceAssemblies transitively; its BCL
+           would sit alongside Unity's and duplicate types such as Queue<T>. -->
+      <FrameworkReferenceToDrop Include="@(ReferencePath)"
+        Condition="$([System.String]::Copy('%(Identity)').ToLower().Contains('microsoft.netframework.referenceassemblies'))" />
+      <ReferencePath Remove="@(FrameworkReferenceToDrop)" />
+      <!-- ResolveAssemblyReferences discards any reference to the core library, so Unity's mscorlib
+           is appended to the compiler's reference list here. -->
+      <ReferencePath Include="$(GameManagedDir)mscorlib.dll" />
+      <ReferencePath Include="$(GameManagedDir)netstandard.dll" />
+      <ReferencePath Include="$(GameManagedDir)System.dll" />
+      <ReferencePath Include="$(GameManagedDir)System.Core.dll" />
+      <ReferencePath Include="$(GameManagedDir)System.Data.dll" />
+      <ReferencePath Include="$(GameManagedDir)System.Xml.dll" />
+      <ReferencePath Include="$(GameManagedDir)System.Xml.Linq.dll" />
+      <ReferencePath Include="$(GameManagedDir)System.Runtime.Serialization.dll" />
+      <ReferencePath Include="$(GameManagedDir)System.Net.Http.dll" />
+      <ReferencePath Include="$(GameManagedDir)System.Numerics.dll" />
+      <ReferencePath Include="$(GameManagedDir)Mono.Security.dll" />
+    </ItemGroup>
+  </Target>
   <Target Name="RemoveConflictingPackageReferences" AfterTargets="ResolveLockFileReferences" BeforeTargets="ResolveAssemblyReferences">
     <ItemGroup>
       <Reference Remove="@(Reference)" Condition="('%(Filename)' == 'SteamVR' Or '%(Filename)' == 'SteamVR_Actions') And $([System.String]::Copy('%(Reference.HintPath)').Contains('valheimgamelibz'))" />
     </ItemGroup>
   </Target>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="make-release.cmd" EnvironmentVariables="
-	    SOLUTION_DIR=$(SolutionDir);
+    <Exec Command="&quot;$(MSBuildProjectDirectory)\make-release.cmd&quot;" EnvironmentVariables="
+	    SOLUTION_DIR=$([MSBuild]::EnsureTrailingSlash($([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\..'))));
 	    GAME_DIR=$(CommonDir)Valheim\;   
 	    TARGET_PATH=$(TargetPath);   
 	    TARGET_DIR=$(TargetDir);  

--- a/ValheimVRMod/make-release.cmd
+++ b/ValheimVRMod/make-release.cmd
@@ -9,7 +9,8 @@ copy "%SOLUTION_DIR%Unity\build\ValheimVR_Data\Managed\Unity.XR.Management.dll" 
 copy "%SOLUTION_DIR%Unity\build\ValheimVR_Data\Managed\Unity.XR.OpenVR.dll" "%GAME_DIR%Valheim_Data\Managed"
 copy "%SOLUTION_DIR%Unity\build\ValheimVR_Data\Managed\UnityEngine.XR.LegacyInputHelpers.dll" "%GAME_DIR%Valheim_Data\Managed"
 copy "%SOLUTION_DIR%Unity\build\ValheimVR_Data\Managed\UnityEngine.SpatialTracking.dll" "%GAME_DIR%Valheim_Data\Managed"
-copy "%SOLUTION_DIR%Unity\build\ValheimVR_Data\Managed\amplify_occlusion.dll" "%GAME_DIR%Valheim_Data\Managed"
+:: Valheim 1.0 defines AmplifyOcclusionEffect inside assembly_valheim, so installing the mod's own
+:: amplify_occlusion.dll would duplicate that type.
 copy "%SOLUTION_DIR%Unity\build\ValheimVR_Data\Managed\final_ik.dll" "%GAME_DIR%Valheim_Data\Managed"
 copy "%SOLUTION_DIR%Unity\build\ValheimVR_Data\Managed\root_motion_demo_assets.dll" "%GAME_DIR%Valheim_Data\Managed"
 copy "%SOLUTION_DIR%Unity\build\ValheimVR_Data\Managed\root_motion_shared.dll" "%GAME_DIR%Valheim_Data\Managed"


### PR DESCRIPTION
Valheim 1.0 moved the game to Unity 6000.0.75f1. This makes VHVR build and run
against it. Tested in a headset on Valheim 1.0.7: the game reaches the main menu,
enters a world, and VR controls work.

## Build

There is no `ValheimGameLibz` / `UnityEngine.Modules` package for 1.0, so the
project now references the installed game directly:

- publicized game and Unity engine assemblies out of
  `valheim_Data/Managed/publicized_assemblies` (produced by Bepinex Publicizer,
  which `README.development.md` already tells you to install);
- Unity's own BCL, because Unity 6 adds `Span` based overloads (e.g.
  `AudioClip.GetData`) whose signatures only resolve against Unity's `mscorlib`.

`CommonDir` still has to point at your Steam library, same as before.

Valheim 1.0 also defines `AmplifyOcclusionEffect` inside `assembly_valheim`, so
the mod's own `amplify_occlusion.dll` is no longer referenced or installed - it
would duplicate a type the game now provides. FinalIK, by contrast, was dropped
from the game entirely, so the mod's `final_ik.dll` is still required.

**The asset bundles did not need rebuilding.** All six bundles are still built
with Unity 2019.4.21f1 and load correctly under Unity 6, including `xrmanager`,
so the XR loader, the SteamVR prefabs and the shaders all come up as before.

## API changes in 1.0

- `InventoryGrid.Element` became a top level `InventoryElement` and exposes
  `GetElementRectTransform()` instead of `m_go`
- `Minimap.OnMapRightClick` -> `Minimap.RemovePinUnderPointer`
- `Minimap.m_instance` -> `s_instance` (the `instance` property is used instead)
- the split slider moved onto the new `SplitDialog` component
- `VisEquipment.SetRightHandEquipped` / `SetLeftHandEquipped` gained a `quality`
  parameter
- the settings prefab was rebuilt, so the gamepad tab is located by its
  `GamepadSettings` component rather than by child name

## Fixes

**Transpilers dropped branch labels.** Replacing an instruction with a freshly
built `CodeInstruction` loses its labels and exception blocks, and Harmony then
fails with `Label #N is not marked`. On 1.0 this is real: the
`ZInput.IsGamepadActive` call that gates camera look in
`PlayerController.LateUpdate` is the target of a `brfalse.s`. This adds
`TranspilerUtils` and routes every in place call rewrite through it. Thanks to
@AlexAllocated, whose draft #719 diagnosed this first - that PR fixes the one
call site by mutating the instruction, this generalises it. The emitted opcode is
unchanged everywhere.

**`CameraEffects` crash aborted VR camera setup.** In 1.0 `CameraEffects.Awake()`
calls `ApplySettings()` immediately and `SetSSAO` dereferences the serialized
`m_amplifyOcclusion`, which is null when the component is added at runtime. The
exception propagated out of `enableVrCamera()` and left the camera half
configured.

**The main menu rendered twice.** 1.0 added `CinematicsManager`, whose camera
renders to the screen at depth 1 with every layer in its culling mask, UI
included, so it drew the world space GUI canvas a second time from its own
transform. Its culling mask no longer includes the layers VHVR renders through
its own cameras, and the intro video is not started in VR since it does not
composite into a headset.

**The right stick did not turn the camera.** VHVR feeds its laser pointer through
a simulated mouse, so `ZInput.IsMouseActive()` is true, and 1.0's `LateUpdate`
checks the mouse branch first - while it is taken, the gamepad branch that reads
`GetJoyRightStickX/Y` never runs. The transpiler now reports the mouse as
inactive too. It also no longer rewrites the `IsGamepadActive` call in 1.0's new
early return at the top of the method, which would have skipped camera look.

**Amplify Occlusion drifted between the eyes.** Its temporal filter accumulates
across frames, and since the eyes render in sequence each blends in the other's
history - grass shading visibly floated independently per eye. The filter is
disabled in VR; the effect and its spatial blur stay.

## Not addressed

`getWorldspaceUiCamera()` still logs `VR Camera is null while creating world
space UI camera`. It is used by the crosshair, enemy HUD and repair indicator, so
those in game HUD elements are likely still affected. I have not tracked that one
down yet.

Beyond reaching a world and confirming controls, I have not played through
extended sessions, so gameplay level VR behaviour is not thoroughly verified.
